### PR TITLE
allow to pass .config file path by env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 ### Q2PRO Makefile ###
 
--include .config
+ifneq ($(CONFIG_FILE),)
+    include $(CONFIG_FILE)
+else
+    -include .config
+endif
 
 ifdef CONFIG_WINDOWS
     CPU ?= x86


### PR DESCRIPTION
it's useful for total conversion games that set `q2pro` as a submodule this way they don't have to modify the `q2pro/.config` file in submodule

for example with a file tree this way:

```
src/q2pro.config
src/q2pro/
```

people just have to do that:

```
make -C src/q2pro CONFIG_FILE=../q2pro.config
```