### PR TITLE
fix build warnings

### DIFF
--- a/src/client/main.c
+++ b/src/client/main.c
@@ -1374,10 +1374,12 @@ static void CL_ConnectionlessPacket(void)
                 break;
             }
             cls.serverProtocol = PROTOCOL_VERSION_R1Q2;
+            /*FALLTHROUGH*/
         case PROTOCOL_VERSION_R1Q2:
             if (mask & 1) {
                 break;
             }
+            /*FALLTHROUGH*/
         default:
             cls.serverProtocol = PROTOCOL_VERSION_DEFAULT;
             break;
@@ -3136,7 +3138,7 @@ unsigned CL_Frame(unsigned msec)
     case SYNC_SLEEP_10:
         // don't run refresh at all
         ref_frame = qfalse;
-        // fall through
+        /*FALLTHROUGH*/
     case SYNC_SLEEP_60:
         // run at limited fps if not active
         if (main_extra < main_msec) {

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -1384,7 +1384,7 @@ void CL_SeekDemoMessage(void)
 
         case svc_print:
             MSG_ReadByte();
-            // fall thorugh
+            /*FALLTHROUGH*/
 
         case svc_centerprint:
         case svc_stufftext:


### PR DESCRIPTION
- ~~allow `common/files.h` to be parsable on its own~~
- add missing prototype when fixing biggun crashes
- use fallthrough syntax that GNU won't warn against