### PR TITLE
ipfilter: don't do useless work

### DIFF
--- a/src/baseq2/g_svcmds.c
+++ b/src/baseq2/g_svcmds.c
@@ -125,6 +125,9 @@ qboolean SV_FilterPacket(char *from)
     } m;
     char *p;
 
+    if (numipfilters == 0)
+        return qfalse;
+
     i = 0;
     p = from;
     while (*p && i < 4) {


### PR DESCRIPTION
Don't perform open-coded strtol(3) if there are no filters. This apparently runs on each packet.