### PR TITLE
fix/add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-.config*
-.q2pro/
-.q2proded/
-.baseq2/
-q2pro
-q2proded
-game*.so
+/.config*
+/.q2pro/
+/.q2proded/
+/.baseq2/
+/q2pro*
+/q2proded*
+/baseq2/
+/game*.so
+/game*.dll


### PR DESCRIPTION
- need a slash prefix to ignore only current directory
- add wildcard to ignore .exe files on Windows builds
- wildcard also ignores output like -fdump-ipa-icf
- ignore /baseq2/ for a good measure