### PR TITLE
Correct behavior (with support of overbright effect) of "intensity", gl_brightness" and "gl_modulate".

### DIFF
--- a/src/refresh/gl/arbfp.h
+++ b/src/refresh/gl/arbfp.h
@@ -2,15 +2,48 @@ static const char gl_prog_warp[] =
     "!!ARBfp1.0\n"
     "OPTION ARB_precision_hint_fastest;\n"
 
-    "TEMP ofs, coord, diffuse;\n"
-    "PARAM amp = { 0.0625, 0.0625 };\n"
+    "TEMP offset, coordinate, diffuse;\n"
+    "PARAM amplitude = { 0.0625, 0.0625 };\n"
     "PARAM phase = { 4, 4 };\n"
 
-    "MAD coord, phase, fragment.texcoord[0], program.local[0];\n"
-    "SIN ofs.x, coord.y;\n"
-    "SIN ofs.y, coord.x;\n"
-    "MAD coord, ofs, amp, fragment.texcoord[0];\n"
-    "TEX diffuse, coord, texture[0], 2D;\n"
+    "MAD coordinate, phase, fragment.texcoord[0], program.local[0];\n"
+
+    "SIN offset.x, coordinate.y;\n"
+    "SIN offset.y, coordinate.x;\n"
+
+    "MAD coordinate, offset, amplitude, fragment.texcoord[0];\n"
+    "TEX diffuse, coordinate, texture[0], 2D;\n"
+
     "MUL result.color, diffuse, fragment.color;\n"
+    "END\n"
+;
+
+static const char gl_prog_lightmapped[] =
+    "!!ARBfp1.0\n"
+
+    "TEMP diffuse, lightmap;\n"
+
+    "TEX diffuse, fragment.texcoord[0], texture[0], 2D;\n"
+    "TEX lightmap, fragment.texcoord[1], texture[1], 2D;\n"
+
+    "MUL diffuse, diffuse, program.local[0];\n"
+    "MAD lightmap, program.local[1], lightmap, program.local[2];\n"
+
+    "MUL diffuse, lightmap, diffuse;\n"
+    "MOV result.color, diffuse;\n"
+
+    "END\n"
+;
+
+static const char gl_prog_alias[] =
+    "!!ARBfp1.0\n"
+
+    "TEMP diffuse;\n"
+
+    "TEX diffuse, fragment.texcoord[0], texture[0], 2D;\n"
+    "MUL diffuse, diffuse, program.local[0];\n"
+
+    "MUL result.color, diffuse, fragment.color;\n"
+
     "END\n"
 ;

--- a/src/refresh/gl/gl.h
+++ b/src/refresh/gl/gl.h
@@ -66,6 +66,8 @@ typedef struct {
         vec_t       size;
     } world;
     GLuint          prognum_warp;
+    GLuint          prognum_lightmapped;
+    GLuint          prognum_alias;
     GLuint          texnums[NUM_TEXNUMS];
     GLbitfield      stencil_buffer_bit;
     float           entity_modulate;
@@ -169,6 +171,7 @@ extern cvar_t *gl_modulate_entities;
 extern cvar_t *gl_doublelight_entities;
 extern cvar_t *gl_fragment_program;
 extern cvar_t *gl_fontshadow;
+extern cvar_t *gl_intensity;
 
 // development variables
 extern cvar_t *gl_znear;
@@ -291,7 +294,8 @@ typedef enum {
     GLS_LIGHTMAP_ENABLE     = (1 << 8),
     GLS_WARP_ENABLE         = (1 << 9),
     GLS_CULL_DISABLE        = (1 << 10),
-    GLS_SHADE_SMOOTH        = (1 << 11)
+    GLS_SHADE_SMOOTH        = (1 << 11),
+    GLS_ALIAS_MESH          = (1 << 12)
 } glStateBits_t;
 
 #define GLS_BLEND_MASK  (GLS_BLEND_BLEND | GLS_BLEND_ADD | GLS_BLEND_MODULATE)

--- a/src/refresh/gl/images.c
+++ b/src/refresh/gl/images.c
@@ -961,5 +961,3 @@ void GL_ShutdownImages(void)
 
     Scrap_Shutdown();
 }
-}
-

--- a/src/refresh/gl/images.c
+++ b/src/refresh/gl/images.c
@@ -43,9 +43,10 @@ static cvar_t *gl_texturebits;
 static cvar_t *gl_texture_non_power_of_two;
 static cvar_t *gl_anisotropy;
 static cvar_t *gl_saturation;
-static cvar_t *gl_intensity;
 static cvar_t *gl_gamma;
 static cvar_t *gl_invert;
+
+cvar_t *gl_intensity;
 
 static int GL_UpscaleLevel(int width, int height, imagetype_t type, imageflags_t flags);
 static void GL_Upload32(byte *data, int width, int height, int baselevel, imagetype_t type, imageflags_t flags);
@@ -691,7 +692,8 @@ static void GL_BuildIntensityTable(void)
     int i, j;
     float f;
 
-    f = Cvar_ClampValue(gl_intensity, 1, 5);
+    f = 1.0f;
+
     for (i = 0; i < 256; i++) {
         j = i * f;
         if (j > 255) {
@@ -873,7 +875,7 @@ void GL_InitImages(void)
     gl_gamma_scale_pics = Cvar_Get("gl_gamma_scale_pics", "0", CVAR_FILES);
     gl_upscale_pcx = Cvar_Get("gl_upscale_pcx", "0", CVAR_FILES);
     gl_saturation = Cvar_Get("gl_saturation", "1", CVAR_FILES);
-    gl_intensity = Cvar_Get("intensity", "1", CVAR_FILES);
+    gl_intensity = Cvar_Get("intensity", "1", CVAR_ARCHIVE);
     gl_invert = Cvar_Get("gl_invert", "0", CVAR_FILES);
     gl_gamma = Cvar_Get("vid_gamma", "1", CVAR_ARCHIVE);
 
@@ -959,3 +961,5 @@ void GL_ShutdownImages(void)
 
     Scrap_Shutdown();
 }
+}
+

--- a/src/refresh/gl/main.c
+++ b/src/refresh/gl/main.c
@@ -694,9 +694,8 @@ static void gl_lightmap_changed(cvar_t *self)
         lm.comp = GL_RGBA; // ES doesn't support internal format != external
     else
         lm.comp = lm.scale ? GL_RGB : GL_LUMINANCE;
-    lm.add = 255 * Cvar_ClampValue(gl_brightness, -1, 1);
-    lm.modulate = Cvar_ClampValue(gl_modulate, 0, 1e6);
-    lm.modulate *= Cvar_ClampValue(gl_modulate_world, 0, 1e6);
+    lm.add = 0.0f;
+    lm.modulate = 1.0f;
     lm.dirty = qtrue; // rebuild all lightmaps next frame
 }
 

--- a/src/refresh/gl/mesh.c
+++ b/src/refresh/gl/mesh.c
@@ -570,7 +570,7 @@ static int texnum_for_mesh(maliasmesh_t *mesh)
 
 static void draw_alias_mesh(maliasmesh_t *mesh)
 {
-    glStateBits_t state = GLS_DEFAULT;
+    glStateBits_t state = GLS_ALIAS_MESH;
 
     // fall back to entity matrix
     GL_LoadMatrix(glr.entmatrix);


### PR DESCRIPTION
Instead of applying tables on CPU side on loading stage, their job was moved into simple ARB shaders which allows to show "correct" ("correct" because it appears like it was created in mind originally, but wasn't implemented due technical restraints of the time) picture without clamping values. With this small change game gets rid of washed out colors (which is common with high gl_modulate values that used by many) and allows to control lighting values in more precise (and more pleasant for eyes) way.

Like for example intensity. If you set it to 2, as example, in rendering you expect that all colors from textures in game will be multiplied by that value. But it was half truth. Because it was made on CPU side, trying to fit into single byte, which meant if color channel value (range 0-255) was 127 and you set intensity to 2 - then that value will become 254. But if original value was higher than 127 - it is just not possible to fit that value into 1 byte, so new value was clamped to 255. In result, overall brightness wasn't changed in way as expected visually (everything 2 times brighter than default dark visuals), meanwhile it lead to washing colors out. So I moved those color manipulations directly into shaders on GPU where it handles that correctly. Same goes as for gl_modulate and gl_brightness, with exception that last ones were just washing out colors from lighting, not just textures themselves, that lead to flat messy colored look.

Example with some acid config... Some ludicrously high values for intensity and gl_modulate.

Was: https://cdn.discordapp.com/attachments/365528612830576641/385130889652207617/quake019.jpg

Become: https://cdn.discordapp.com/attachments/365528612830576641/385130909021765632/quake020.jpg

Was: https://cdn.discordapp.com/attachments/365528612830576641/385130933684011019/quake018.jpg

Become: https://cdn.discordapp.com/attachments/365528612830576641/385130969272811530/quake017-1.jpg