### PR TITLE
cleanup warnings

### DIFF
--- a/inc/common/common.h
+++ b/inc/common/common.h
@@ -54,8 +54,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define CONST_STR_LEN(x) x, x ? sizeof(x) - 1 : 0
 
-#define __STRINGIFY(x)  #x
-#define STRINGIFY(x)    __STRINGIFY(x)
+#define STRINGIFY2(x)   #x
+#define STRINGIFY(x)    STRINGIFY2(x)
 
 typedef struct {
     const char *name;

--- a/src/baseq2/g_spawn.c
+++ b/src/baseq2/g_spawn.c
@@ -855,9 +855,9 @@ void SP_worldspawn(edict_t *ent)
 
     if (ent->message && ent->message[0]) {
         gi.configstring(CS_NAME, ent->message);
-        strncpy(level.level_name, ent->message, sizeof(level.level_name));
+        Q_strlcpy(level.level_name, ent->message, sizeof(level.level_name));
     } else
-        strncpy(level.level_name, level.mapname, sizeof(level.level_name));
+        Q_strlcpy(level.level_name, level.mapname, sizeof(level.level_name));
 
     if (st.sky && st.sky[0])
         gi.configstring(CS_SKY, st.sky);

--- a/src/baseq2/g_target.c
+++ b/src/baseq2/g_target.c
@@ -86,7 +86,7 @@ void SP_target_speaker(edict_t *ent)
     if (!strstr(st.noise, ".wav"))
         Q_snprintf(buffer, sizeof(buffer), "%s.wav", st.noise);
     else
-        strncpy(buffer, st.noise, sizeof(buffer));
+        Q_strlcpy(buffer, st.noise, sizeof(buffer));
     ent->noise_index = gi.soundindex(buffer);
 
     if (!ent->volume)

--- a/src/windows/system.c
+++ b/src/windows/system.c
@@ -783,7 +783,7 @@ void Sys_Init(void)
     HMODULE module;
     BOOL (WINAPI * pSetProcessDEPPolicy)(DWORD);
 #endif
-    cvar_t *var = NULL;
+    cvar_t *var q_unused = NULL;
 
     // check windows version
     vinfo.dwOSVersionInfoSize = sizeof(vinfo);


### PR DESCRIPTION
In particular `_STRINGIFY' is defined in mingw-w64
internal headers. The underscore-prefixed names are
reserved.