### PR TITLE
make debug info readable on LCD's

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -432,7 +432,7 @@ void Com_LPrintf(print_type_t type, const char *fmt, ...)
             Com_SetColor(COLOR_ALT);
             break;
         case PRINT_DEVELOPER:
-            Com_SetColor(COLOR_BLUE);
+            Com_SetColor(COLOR_GREEN);
             break;
         case PRINT_WARNING:
             Com_SetColor(COLOR_YELLOW);


### PR DESCRIPTION
I can't see the blue text ingame.