### PR TITLE
add /opentdm/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /game*.dll
 /tags
 /TAGS
+/opentdm/


### PR DESCRIPTION
`opentdm` is the multiplayer mod most likely used with q2pro. 