### PR TITLE
fix build with libjpeg

### DIFF
--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -39,6 +39,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <jpeglib.h>
 #endif
 
+#include <setjmp.h>
+
 #define R_COLORMAP_PCX    "pics/colormap.pcx"
 
 #define IMG_LOAD(x) \


### PR DESCRIPTION
Build fails if libjpeg is used but libpng isn't. The `setjmp.h` header is implicitly included in the latter.
