### PR TITLE
fix syscon fatal exit on ^Z

### DIFF
--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -356,7 +356,7 @@ void Sys_RunConsole(void)
     tty_io->canread = false;
 
     if (ret < 0) {
-        if (errno == EAGAIN) {
+        if (errno == EAGAIN || errno == EIO) {
             return;
         }
         tty_fatal_error("read");


### PR DESCRIPTION
I'm unsure what's the right behavior here. Maybe we should raise `SIGSTOP` in the handler? The current behavior of a fatal exit is hardly sensible however.