### PR TITLE
allow drop root privileges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,12 @@ else
         LDFLAGS_g += -Wl,--no-undefined
     endif
 
+    ifdef CONFIG_DROP_PRIVS_UID
+        ifdef CONFIG_DROP_PRIVS_GID
+            CFLAGS_s += -DDROP_PRIVS_UID=$(CONFIG_DROP_PRIVS_UID) -DDROP_PRIVS_GID=$(CONFIG_DROP_PRIVS_GID)
+        endif
+    endif
+
     CFLAGS_s += -D_FILE_OFFSET_BITS=64
     CFLAGS_c += -D_FILE_OFFSET_BITS=64
     CFLAGS_g += -fPIC


### PR DESCRIPTION
Using a pure shell invocation of `chroot(8)` (the shell command) I was unable to run `q2proded` as non-superuser without a scripting language. The full invocation was

    chroot . sudo -nu nobody ./q2proded +set game opentdm +exec server.cfg

that's a catch-22, given `chroot(2)` requires superuser permission but the chroot itself doesn't contain a Unix root filesystem–merely the dynamic linker, libc, q2proded, the opentdm shared object, server config and maps. 

Of course, a short Perl invocation would have no problem with the chroot-and-drop-privs sequence.
