### PR TITLE
appease harmless compiler warnings

### DIFF
--- a/src/baseq2/p_view.c
+++ b/src/baseq2/p_view.c
@@ -960,7 +960,7 @@ void ClientEndServerFrame(edict_t *ent)
         bobtime *= 4;
 
     bobcycle = (int)bobtime;
-    bobfracsin = fabsf(sin(bobtime * M_PI));
+    bobfracsin = fabsf(sinf(bobtime * M_PI));
 
     // detect hitting the floor
     P_FallingDamage(ent);

--- a/src/windows/client.c
+++ b/src/windows/client.c
@@ -850,7 +850,7 @@ static void pos_changed_event(HWND wnd, WINDOWPOS *pos)
 }
 
 // main window procedure
-STATIC LONG WINAPI Win_MainWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+STATIC LRESULT WINAPI Win_MainWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg) {
     case WM_MOUSEWHEEL:


### PR DESCRIPTION
 These are harmless even despite the return type size mismatch UB.
