### PR TITLE
Windows compilation improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /game*.dll
 /tags
 /TAGS
+/vs/.vs

--- a/inc/common/cmd.h
+++ b/inc/common/cmd.h
@@ -204,4 +204,10 @@ void Cmd_PrintHelp(const cmd_option_t *opt);
 void Cmd_PrintUsage(const cmd_option_t *opt, const char *suffix);
 void Cmd_PrintHint(void);
 
+#if USE_SERVER && USE_WASM
+void Cmd_DestroyWASMLinkage(void);
+uint32_t Cmd_RawArgsWASM(void);
+uint32_t Cmd_ArgvWASM(int arg);
+#endif
+
 #endif // CMD_H

--- a/inc/common/cvar.h
+++ b/inc/common/cvar.h
@@ -124,4 +124,8 @@ char *Cvar_VariableString(const char *var_name);
 
 void Cvar_Set_f(void);
 
+#if USE_SERVER && USE_WASM
+void Cvar_DestroyWASMLinkage(void);
+#endif
+
 #endif // CVAR_H

--- a/inc/common/error.h
+++ b/inc/common/error.h
@@ -73,7 +73,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define Q_ERR_PERM              Q_ERR(EPERM)
 
 // This macro converts system errno into quake error value.
+#ifdef _MSC_VER
+int Q_ErrorNumber(void);
+#define Q_ERRNO					Q_ErrorNumber()
+#else
 #define Q_ERRNO                 ({int e = errno; Q_ERR(e);})
+#endif
 
 const char *Q_ErrorString(int error);
 

--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -41,6 +41,9 @@ typedef enum {
     TAG_MVD,
     TAG_SOUND,
     TAG_CMODEL,
+#if USE_WASM
+    TAG_WASM,
+#endif
 
     TAG_MAX
 } memtag_t;

--- a/inc/server/server.h
+++ b/inc/server/server.h
@@ -48,4 +48,17 @@ int MVD_GetDemoPercent(bool *paused, int *framenum);
 char *SV_GetSaveInfo(const char *dir);
 #endif
 
+#if USE_SERVER && USE_WASM
+bool SV_IsWASMRunning(void);
+bool SV_ValidateWASMAddress(wasm_address_t address, uint32_t size);
+// Be wary of the three functions below: when memory grows on the WASM side,
+// native pointers may not be pointing to the same place they were before.
+// Its lifetime should only be considered to be valid *up until* the next WASM
+// function call.
+wasm_address_t SV_AllocateWASMMemory(uint32_t size);
+void SV_FreeWASMMemory(wasm_address_t addr);
+void *SV_ResolveWASMAddress(wasm_address_t address);
+wasm_address_t SV_UnresolveWASMAddress(void *pointer);
+#endif
+
 #endif // SERVER_H

--- a/inc/shared/game.h
+++ b/inc/shared/game.h
@@ -197,6 +197,6 @@ NATIVE_LINKAGE void NATIVE_IMPORT(gi_DebugGraph)(float value, int color);
 
 #endif      // GAME_INCLUDE
 
-#include "wasm_game.h"
+#include "game_ext.h"
 
 #endif // GAME_H

--- a/inc/shared/game.h
+++ b/inc/shared/game.h
@@ -58,10 +58,15 @@ typedef enum {
 
 #define MAX_ENT_CLUSTERS    16
 
-
 typedef struct edict_s edict_t;
 typedef struct gclient_s gclient_t;
 
+typedef struct {
+    edict_t *edicts;
+    int     edict_size;
+    int     num_edicts;     // current number, <= max_edicts
+    int     max_edicts;
+} edict_pool_t;
 
 #ifndef GAME_INCLUDE
 
@@ -73,7 +78,6 @@ struct gclient_s {
     // this point in the structure
     int             clientNum;
 };
-
 
 struct edict_s {
     entity_state_t  s;
@@ -102,142 +106,97 @@ struct edict_s {
     // this point in the structure
 };
 
+#else
+
+// Imported function declarations. These are imported on WASM,
+// but wrap the function pointers on native, except for the
+// "formatted" string functions which have slightly different
+// implementations on WASM.
+#if __wasm__
+#define NATIVE_IMPORT
+#else
+#define NATIVE_IMPORT(x) (* x)
+#endif
+
+#ifndef NATIVE_LINKAGE
+#define NATIVE_LINKAGE extern
+#endif
+
+// special messages
+NATIVE_LINKAGE void NATIVE_IMPORT(q_printf(2, 3) gi_bprintf)(int printlevel, const char *fmt, ...);
+NATIVE_LINKAGE void NATIVE_IMPORT(q_printf(1, 2) gi_dprintf)(const char *fmt, ...);
+NATIVE_LINKAGE void NATIVE_IMPORT(q_printf(3, 4) gi_cprintf)(edict_t *ent, int printlevel, const char *fmt, ...);
+NATIVE_LINKAGE void NATIVE_IMPORT(q_printf(2, 3) gi_centerprintf)(edict_t *ent, const char *fmt, ...);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_sound)(edict_t *ent, int channel, int soundindex, float volume, float attenuation, float timeofs);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_positioned_sound)(vec3_t origin, edict_t *ent, int channel, int soundinedex, float volume, float attenuation, float timeofs);
+
+// config strings hold all the index strings, the lightstyles,
+// and misc data like the sky definition and cdtrack.
+// All of the current configstrings are sent to clients when
+// they connect, and changes are sent to all connected clients.
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_configstring)(int num, const char *string);
+
+NATIVE_LINKAGE void NATIVE_IMPORT(q_noreturn q_printf(1, 2) gi_error)(const char *fmt, ...);
+
+// the *index functions create configstrings and some internal server state
+NATIVE_LINKAGE int NATIVE_IMPORT(gi_modelindex)(const char *name);
+NATIVE_LINKAGE int NATIVE_IMPORT(gi_soundindex)(const char *name);
+NATIVE_LINKAGE int NATIVE_IMPORT(gi_imageindex)(const char *name);
+
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_setmodel)(edict_t *ent, const char *name);
+
+// collision detection
+NATIVE_LINKAGE trace_t NATIVE_IMPORT(q_gameabi gi_trace)(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, edict_t *passent, int contentmask);
+NATIVE_LINKAGE int NATIVE_IMPORT(gi_pointcontents)(vec3_t point);
+NATIVE_LINKAGE qboolean NATIVE_IMPORT(gi_inPVS)(vec3_t p1, vec3_t p2);
+NATIVE_LINKAGE qboolean NATIVE_IMPORT(gi_inPHS)(vec3_t p1, vec3_t p2);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_SetAreaPortalState)(int portalnum, qboolean open);
+NATIVE_LINKAGE qboolean NATIVE_IMPORT(gi_AreasConnected)(int area1, int area2);
+
+// an entity will never be sent to a client or used for collision
+// if it is not passed to linkentity.  If the size, position, or
+// solidity changes, it must be relinked.
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_linkentity)(edict_t *ent);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_unlinkentity)(edict_t *ent);     // call before removing an interactive edict
+NATIVE_LINKAGE int NATIVE_IMPORT(gi_BoxEdicts)(vec3_t mins, vec3_t maxs, edict_t **list, int maxcount, int areatype);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_Pmove)(pmove_t *pmove);          // player movement code common with client prediction
+
+// network messaging
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_multicast)(vec3_t origin, multicast_t to);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_unicast)(edict_t *ent, qboolean reliable);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WriteChar)(int c);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WriteByte)(int c);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WriteShort)(int c);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WriteLong)(int c);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WriteFloat)(float f);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WriteString)(const char *s);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WritePosition)(const vec3_t pos);    // some fractional bits
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WriteDir)(const vec3_t pos);         // single byte encoded, very coarse
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_WriteAngle)(float f);
+
+// managed memory allocation
+NATIVE_LINKAGE void *NATIVE_IMPORT(gi_TagMalloc)(unsigned size, unsigned tag);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_TagFree)(void *block);
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_FreeTags)(unsigned tag);
+
+// console variable interaction
+NATIVE_LINKAGE cvar_t *NATIVE_IMPORT(gi_cvar)(const char *var_name, const char *value, int flags);
+NATIVE_LINKAGE cvar_t *NATIVE_IMPORT(gi_cvar_set)(const char *var_name, const char *value);
+NATIVE_LINKAGE cvar_t *NATIVE_IMPORT(gi_cvar_forceset)(const char *var_name, const char *value);
+
+// ClientCommand and ServerCommand parameter access
+NATIVE_LINKAGE int NATIVE_IMPORT(gi_argc)(void);
+NATIVE_LINKAGE char *NATIVE_IMPORT(gi_argv)(int n);
+NATIVE_LINKAGE char *NATIVE_IMPORT(gi_args)(void);     // concatenation of all argv >= 1
+
+// add commands to the server console as if they were typed in
+// for map changing, etc
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_AddCommandString)(const char *text);
+
+NATIVE_LINKAGE void NATIVE_IMPORT(gi_DebugGraph)(float value, int color);
+
 #endif      // GAME_INCLUDE
 
-//===============================================================
-
-//
-// functions provided by the main engine
-//
-typedef struct {
-    // special messages
-    void (* q_printf(2, 3) bprintf)(int printlevel, const char *fmt, ...);
-    void (* q_printf(1, 2) dprintf)(const char *fmt, ...);
-    void (* q_printf(3, 4) cprintf)(edict_t *ent, int printlevel, const char *fmt, ...);
-    void (* q_printf(2, 3) centerprintf)(edict_t *ent, const char *fmt, ...);
-    void (*sound)(edict_t *ent, int channel, int soundindex, float volume, float attenuation, float timeofs);
-    void (*positioned_sound)(vec3_t origin, edict_t *ent, int channel, int soundinedex, float volume, float attenuation, float timeofs);
-
-    // config strings hold all the index strings, the lightstyles,
-    // and misc data like the sky definition and cdtrack.
-    // All of the current configstrings are sent to clients when
-    // they connect, and changes are sent to all connected clients.
-    void (*configstring)(int num, const char *string);
-
-    void (* q_noreturn q_printf(1, 2) error)(const char *fmt, ...);
-
-    // the *index functions create configstrings and some internal server state
-    int (*modelindex)(const char *name);
-    int (*soundindex)(const char *name);
-    int (*imageindex)(const char *name);
-
-    void (*setmodel)(edict_t *ent, const char *name);
-
-    // collision detection
-    trace_t (* q_gameabi trace)(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, edict_t *passent, int contentmask);
-    int (*pointcontents)(vec3_t point);
-    qboolean (*inPVS)(vec3_t p1, vec3_t p2);
-    qboolean (*inPHS)(vec3_t p1, vec3_t p2);
-    void (*SetAreaPortalState)(int portalnum, qboolean open);
-    qboolean (*AreasConnected)(int area1, int area2);
-
-    // an entity will never be sent to a client or used for collision
-    // if it is not passed to linkentity.  If the size, position, or
-    // solidity changes, it must be relinked.
-    void (*linkentity)(edict_t *ent);
-    void (*unlinkentity)(edict_t *ent);     // call before removing an interactive edict
-    int (*BoxEdicts)(vec3_t mins, vec3_t maxs, edict_t **list, int maxcount, int areatype);
-    void (*Pmove)(pmove_t *pmove);          // player movement code common with client prediction
-
-    // network messaging
-    void (*multicast)(vec3_t origin, multicast_t to);
-    void (*unicast)(edict_t *ent, qboolean reliable);
-    void (*WriteChar)(int c);
-    void (*WriteByte)(int c);
-    void (*WriteShort)(int c);
-    void (*WriteLong)(int c);
-    void (*WriteFloat)(float f);
-    void (*WriteString)(const char *s);
-    void (*WritePosition)(const vec3_t pos);    // some fractional bits
-    void (*WriteDir)(const vec3_t pos);         // single byte encoded, very coarse
-    void (*WriteAngle)(float f);
-
-    // managed memory allocation
-    void *(*TagMalloc)(unsigned size, unsigned tag);
-    void (*TagFree)(void *block);
-    void (*FreeTags)(unsigned tag);
-
-    // console variable interaction
-    cvar_t *(*cvar)(const char *var_name, const char *value, int flags);
-    cvar_t *(*cvar_set)(const char *var_name, const char *value);
-    cvar_t *(*cvar_forceset)(const char *var_name, const char *value);
-
-    // ClientCommand and ServerCommand parameter access
-    int (*argc)(void);
-    char *(*argv)(int n);
-    char *(*args)(void);     // concatenation of all argv >= 1
-
-    // add commands to the server console as if they were typed in
-    // for map changing, etc
-    void (*AddCommandString)(const char *text);
-
-    void (*DebugGraph)(float value, int color);
-} game_import_t;
-
-//
-// functions exported by the game subsystem
-//
-typedef struct {
-    int         apiversion;
-
-    // the init function will only be called when a game starts,
-    // not each time a level is loaded.  Persistant data for clients
-    // and the server can be allocated in init
-    void (*Init)(void);
-    void (*Shutdown)(void);
-
-    // each new level entered will cause a call to SpawnEntities
-    void (*SpawnEntities)(const char *mapname, const char *entstring, const char *spawnpoint);
-
-    // Read/Write Game is for storing persistant cross level information
-    // about the world state and the clients.
-    // WriteGame is called every time a level is exited.
-    // ReadGame is called on a loadgame.
-    void (*WriteGame)(const char *filename, qboolean autosave);
-    void (*ReadGame)(const char *filename);
-
-    // ReadLevel is called after the default map information has been
-    // loaded with SpawnEntities
-    void (*WriteLevel)(const char *filename);
-    void (*ReadLevel)(const char *filename);
-
-    qboolean (*ClientConnect)(edict_t *ent, char *userinfo);
-    void (*ClientBegin)(edict_t *ent);
-    void (*ClientUserinfoChanged)(edict_t *ent, char *userinfo);
-    void (*ClientDisconnect)(edict_t *ent);
-    void (*ClientCommand)(edict_t *ent);
-    void (*ClientThink)(edict_t *ent, usercmd_t *cmd);
-
-    void (*RunFrame)(void);
-
-    // ServerCommand will be called when an "sv <command>" command is issued on the
-    // server console.
-    // The game can issue gi.argc() / gi.argv() commands to get the rest
-    // of the parameters
-    void (*ServerCommand)(void);
-
-    //
-    // global variables shared between game and server
-    //
-
-    // The edict array is allocated in the game dll so it
-    // can vary in size from one game to another.
-    //
-    // The size will be fixed when ge->Init() is called
-    struct edict_s  *edicts;
-    int         edict_size;
-    int         num_edicts;     // current number, <= max_edicts
-    int         max_edicts;
-} game_export_t;
+#include "wasm_game.h"
 
 #endif // GAME_H

--- a/inc/shared/game_ext.h
+++ b/inc/shared/game_ext.h
@@ -16,8 +16,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef WASM_GAME_H
-#define WASM_GAME_H
+#ifndef GAME_EXT_H
+#define GAME_EXT_H
 
 #include <stdint.h>
 #include "game.h"
@@ -26,7 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Chosen because:
 // - 'W' in ASCII
 // - Doesn't conflict with any known API versions
-#define WASM_API_VERSION    87
+#define GAME_API_EXTENDED_VERSION    87
 
 // This may seem weird, but, since WASM doesn't deal with
 // import/export as function pointers this is completely legal.
@@ -49,13 +49,13 @@ typedef struct {
     int32_t apiversion;
     
     game_capability_t (*QueryEngineCapability)(const char *cap);
-} wasm_game_import_t;
+} game_import_87_t;
 
 typedef struct {
     game_export_t   ge;
     
     game_capability_t (*QueryGameCapability)(const char *cap);
-} wasm_game_export_t;
+} game_export_87_t;
 
 #ifdef GAME_INCLUDE
 // see game.h for what NATIVE_IMPORT does.
@@ -65,7 +65,6 @@ NATIVE_LINKAGE game_capability_t NATIVE_IMPORT(gi_QueryEngineCapability)(const c
 // =====
 // non_standard_layout::xxx 
 // =====
-// Shared with WASM modules
 typedef enum {
     WF_INVALID,
 
@@ -78,7 +77,7 @@ typedef enum {
     WF_POINTER,
 
     WF_UNSIGNED = 32
-} wasm_field_type_t;
+} game_field_type_t;
 
 #define WF_FIELD_TYPE(t) \
     ((t) & ~WF_UNSIGNED)
@@ -87,9 +86,9 @@ typedef enum {
     ((t) & WF_UNSIGNED)
 
 typedef struct {
-    wasm_field_type_t   type;
+    game_field_type_t   type;
     uint32_t            offset;
     uint32_t            count;
-} wasm_field_t;
+} game_field_t;
 
-#endif // WASM_GAME_H
+#endif // GAME_EXT_H

--- a/inc/shared/native.h
+++ b/inc/shared/native.h
@@ -1,0 +1,157 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef NATIVE_H
+#define NATIVE_H
+
+#include "game.h"
+
+//===============================================================
+
+//
+// functions provided by the main engine
+//
+typedef struct {
+    // special messages
+    void (* q_printf(2, 3) bprintf)(int printlevel, const char *fmt, ...);
+    void (* q_printf(1, 2) dprintf)(const char *fmt, ...);
+    void (* q_printf(3, 4) cprintf)(edict_t *ent, int printlevel, const char *fmt, ...);
+    void (* q_printf(2, 3) centerprintf)(edict_t *ent, const char *fmt, ...);
+    void (*sound)(edict_t *ent, int channel, int soundindex, float volume, float attenuation, float timeofs);
+    void (*positioned_sound)(vec3_t origin, edict_t *ent, int channel, int soundinedex, float volume, float attenuation, float timeofs);
+
+    // config strings hold all the index strings, the lightstyles,
+    // and misc data like the sky definition and cdtrack.
+    // All of the current configstrings are sent to clients when
+    // they connect, and changes are sent to all connected clients.
+    void (*configstring)(int num, const char *string);
+
+    void (* q_noreturn q_printf(1, 2) error)(const char *fmt, ...);
+
+    // the *index functions create configstrings and some internal server state
+    int (*modelindex)(const char *name);
+    int (*soundindex)(const char *name);
+    int (*imageindex)(const char *name);
+
+    void (*setmodel)(edict_t *ent, const char *name);
+
+    // collision detection
+    trace_t (* q_gameabi trace)(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, edict_t *passent, int contentmask);
+    int (*pointcontents)(vec3_t point);
+    qboolean (*inPVS)(vec3_t p1, vec3_t p2);
+    qboolean (*inPHS)(vec3_t p1, vec3_t p2);
+    void (*SetAreaPortalState)(int portalnum, qboolean open);
+    qboolean (*AreasConnected)(int area1, int area2);
+
+    // an entity will never be sent to a client or used for collision
+    // if it is not passed to linkentity.  If the size, position, or
+    // solidity changes, it must be relinked.
+    void (*linkentity)(edict_t *ent);
+    void (*unlinkentity)(edict_t *ent);     // call before removing an interactive edict
+    int (*BoxEdicts)(vec3_t mins, vec3_t maxs, edict_t **list, int maxcount, int areatype);
+    void (*Pmove)(pmove_t *pmove);          // player movement code common with client prediction
+
+    // network messaging
+    void (*multicast)(vec3_t origin, multicast_t to);
+    void (*unicast)(edict_t *ent, qboolean reliable);
+    void (*WriteChar)(int c);
+    void (*WriteByte)(int c);
+    void (*WriteShort)(int c);
+    void (*WriteLong)(int c);
+    void (*WriteFloat)(float f);
+    void (*WriteString)(const char *s);
+    void (*WritePosition)(const vec3_t pos);    // some fractional bits
+    void (*WriteDir)(const vec3_t pos);         // single byte encoded, very coarse
+    void (*WriteAngle)(float f);
+
+    // managed memory allocation
+    void *(*TagMalloc)(unsigned size, unsigned tag);
+    void (*TagFree)(void *block);
+    void (*FreeTags)(unsigned tag);
+
+    // console variable interaction
+    cvar_t *(*cvar)(const char *var_name, const char *value, int flags);
+    cvar_t *(*cvar_set)(const char *var_name, const char *value);
+    cvar_t *(*cvar_forceset)(const char *var_name, const char *value);
+
+    // ClientCommand and ServerCommand parameter access
+    int (*argc)(void);
+    char *(*argv)(int n);
+    char *(*args)(void);     // concatenation of all argv >= 1
+
+    // add commands to the server console as if they were typed in
+    // for map changing, etc
+    void (*AddCommandString)(const char *text);
+
+    void (*DebugGraph)(float value, int color);
+} game_import_t;
+
+//
+// functions exported by the game subsystem
+//
+typedef struct {
+    int         apiversion;
+
+    // the init function will only be called when a game starts,
+    // not each time a level is loaded.  Persistant data for clients
+    // and the server can be allocated in init
+    void (*Init)(void);
+    void (*Shutdown)(void);
+
+    // each new level entered will cause a call to SpawnEntities
+    void (*SpawnEntities)(const char *mapname, const char *entstring, const char *spawnpoint);
+
+    // Read/Write Game is for storing persistant cross level information
+    // about the world state and the clients.
+    // WriteGame is called every time a level is exited.
+    // ReadGame is called on a loadgame.
+    void (*WriteGame)(const char *filename, qboolean autosave);
+    void (*ReadGame)(const char *filename);
+
+    // ReadLevel is called after the default map information has been
+    // loaded with SpawnEntities
+    void (*WriteLevel)(const char *filename);
+    void (*ReadLevel)(const char *filename);
+
+    qboolean (*ClientConnect)(edict_t *ent, char *userinfo);
+    void (*ClientBegin)(edict_t *ent);
+    void (*ClientUserinfoChanged)(edict_t *ent, char *userinfo);
+    void (*ClientDisconnect)(edict_t *ent);
+    void (*ClientCommand)(edict_t *ent);
+    void (*ClientThink)(edict_t *ent, usercmd_t *cmd);
+
+    void (*RunFrame)(void);
+
+    // ServerCommand will be called when an "sv <command>" command is issued on the
+    // server console.
+    // The game can issue gi.argc() / gi.argv() commands to get the rest
+    // of the parameters
+    void (*ServerCommand)(void);
+
+    //
+    // global variables shared between game and server
+    //
+
+    // The edict array is allocated in the game dll so it
+    // can vary in size from one game to another.
+    //
+    // The size will be fixed when ge->Init() is called
+    edict_pool_t pool;
+} game_export_t;
+
+#endif // NATIVE_H

--- a/inc/shared/platform.h
+++ b/inc/shared/platform.h
@@ -42,6 +42,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define LIBSUFFIX   ".so"
 #endif
 
+#if USE_WASM
+#define WASMSUFFIX	".wasm"
+#endif
+
 #ifdef _WIN32
 #define PATH_SEP_CHAR       '\\'
 #define PATH_SEP_STRING     "\\"

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -575,6 +575,17 @@ size_t  Info_SubValidate(const char *s);
 void    Info_NextPair(const char **string, char *key, char *value);
 void    Info_Print(const char *infostring);
 
+#if USE_WASM
+/*
+==========================================================
+
+WASM Game Modules
+
+==========================================================
+*/
+typedef uint32_t wasm_address_t;
+#endif
+
 /*
 ==========================================================
 
@@ -615,6 +626,11 @@ typedef struct cvar_s {
     xchanged_t      changed;
     xgenerator_t    generator;
     struct cvar_s   *hashNext;
+#if USE_WASM
+    wasm_address_t wasm;
+    uint32_t wasm_string_size; // size *in bytes*
+    uint32_t wasm_latched_string_size; // size *in bytes*
+#endif
 } cvar_t;
 
 #endif      // CVAR

--- a/inc/shared/wasm_game.h
+++ b/inc/shared/wasm_game.h
@@ -1,0 +1,95 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef WASM_GAME_H
+#define WASM_GAME_H
+
+#include <stdint.h>
+#include "game.h"
+#include "native.h"
+
+// Chosen because:
+// - 'W' in ASCII
+// - Doesn't conflict with any known API versions
+#define WASM_API_VERSION    87
+
+// This may seem weird, but, since WASM doesn't deal with
+// import/export as function pointers this is completely legal.
+// On WASM, a capability check will either return true or false.
+// On native, however, it will return a function pointer, or NULL.
+// Note that the Query*Capability functions are only guaranteed to
+// "work" before InitGame has completed execution. Any usage of the
+// function after that should always return NULL.
+#ifdef __wasm__
+typedef qboolean game_capability_t;
+#define CAPABILITY_FALSE false
+#else
+typedef void (*game_capability_t)();
+#define CAPABILITY_FALSE NULL
+#endif
+
+typedef struct {
+    game_import_t   gi;
+
+    int32_t apiversion;
+    
+    game_capability_t (*QueryEngineCapability)(const char *cap);
+} wasm_game_import_t;
+
+typedef struct {
+    game_export_t   ge;
+    
+    game_capability_t (*QueryGameCapability)(const char *cap);
+} wasm_game_export_t;
+
+#ifdef GAME_INCLUDE
+// see game.h for what NATIVE_IMPORT does.
+NATIVE_LINKAGE game_capability_t NATIVE_IMPORT(gi_QueryEngineCapability)(const char *cap);
+#endif
+
+// =====
+// non_standard_layout::xxx 
+// =====
+// Shared with WASM modules
+typedef enum {
+    WF_INVALID,
+
+    WF_INT8,
+    WF_INT16,
+    WF_INT32,
+    WF_INT64,
+    WF_FLOAT32,
+    WF_FLOAT64,
+    WF_POINTER,
+
+    WF_UNSIGNED = 32
+} wasm_field_type_t;
+
+#define WF_FIELD_TYPE(t) \
+    ((t) & ~WF_UNSIGNED)
+
+#define WF_FIELD_FLAGS(t) \
+    ((t) & WF_UNSIGNED)
+
+typedef struct {
+    wasm_field_type_t   type;
+    uint32_t            offset;
+    uint32_t            count;
+} wasm_field_t;
+
+#endif // WASM_GAME_H

--- a/inc/system/system.h
+++ b/inc/system/system.h
@@ -81,4 +81,9 @@ extern cvar_t   *sys_libdir;
 extern cvar_t   *sys_homedir;
 extern cvar_t   *sys_forcegamelib;
 
+#if USE_WASM
+extern cvar_t   *sys_wasmstacksize;
+extern cvar_t   *sys_wasmheapsize;
+#endif
+
 #endif // SYSTEM_H

--- a/inc/system/system.h
+++ b/inc/system/system.h
@@ -84,6 +84,7 @@ extern cvar_t   *sys_forcegamelib;
 #if USE_WASM
 extern cvar_t   *sys_wasmstacksize;
 extern cvar_t   *sys_wasmheapsize;
+extern cvar_t   *sys_nowasm;
 #endif
 
 #endif // SYSTEM_H

--- a/src/baseq2/g_ai.c
+++ b/src/baseq2/g_ai.c
@@ -275,7 +275,7 @@ bool visible(edict_t *self, edict_t *other)
     spot1[2] += self->viewheight;
     VectorCopy(other->s.origin, spot2);
     spot2[2] += other->viewheight;
-    trace = gi.trace(spot1, vec3_origin, vec3_origin, spot2, self, MASK_OPAQUE);
+    trace = gi_trace(spot1, vec3_origin, vec3_origin, spot2, self, MASK_OPAQUE);
 
     if (trace.fraction == 1.0f)
         return true;
@@ -348,7 +348,7 @@ void FoundTarget(edict_t *self)
     if (!self->movetarget) {
         self->goalentity = self->movetarget = self->enemy;
         HuntTarget(self);
-        gi.dprintf("%s at %s, combattarget %s not found\n", self->classname, vtos(self->s.origin), self->combattarget);
+        gi_dprintf("%s at %s, combattarget %s not found\n", self->classname, vtos(self->s.origin), self->combattarget);
         return;
     }
 
@@ -494,7 +494,7 @@ bool FindTarget(edict_t *self)
             if (!visible(self, client))
                 return false;
         } else {
-            if (!gi.inPHS(self->s.origin, client->s.origin))
+            if (!gi_inPHS(self->s.origin, client->s.origin))
                 return false;
         }
 
@@ -506,7 +506,7 @@ bool FindTarget(edict_t *self)
 
         // check area portals - if they are different and not connected then we can't hear it
         if (client->areanum != self->areanum)
-            if (!gi.AreasConnected(self->areanum, client->areanum))
+            if (!gi_AreasConnected(self->areanum, client->areanum))
                 return false;
 
         self->ideal_yaw = vectoyaw(temp);
@@ -563,7 +563,7 @@ bool M_CheckAttack(edict_t *self)
         VectorCopy(self->enemy->s.origin, spot2);
         spot2[2] += self->enemy->viewheight;
 
-        tr = gi.trace(spot1, NULL, NULL, spot2, self, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_SLIME | CONTENTS_LAVA | CONTENTS_WINDOW);
+        tr = gi_trace(spot1, NULL, NULL, spot2, self, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_SLIME | CONTENTS_LAVA | CONTENTS_WINDOW);
 
         // do we have a clear shot?
         if (tr.ent != self->enemy)
@@ -938,9 +938,9 @@ void ai_run(edict_t *self, float dist)
     VectorCopy(self->monsterinfo.last_sighting, self->goalentity->s.origin);
 
     if (new) {
-//      gi.dprintf("checking for course correction\n");
+//      gi_dprintf("checking for course correction\n");
 
-        tr = gi.trace(self->s.origin, self->mins, self->maxs, self->monsterinfo.last_sighting, self, MASK_PLAYERSOLID);
+        tr = gi_trace(self->s.origin, self->mins, self->maxs, self->monsterinfo.last_sighting, self, MASK_PLAYERSOLID);
         if (tr.fraction < 1) {
             VectorSubtract(self->goalentity->s.origin, self->s.origin, v);
             d1 = VectorLength(v);
@@ -951,12 +951,12 @@ void ai_run(edict_t *self, float dist)
 
             VectorSet(v, d2, -16, 0);
             G_ProjectSource(self->s.origin, v, v_forward, v_right, left_target);
-            tr = gi.trace(self->s.origin, self->mins, self->maxs, left_target, self, MASK_PLAYERSOLID);
+            tr = gi_trace(self->s.origin, self->mins, self->maxs, left_target, self, MASK_PLAYERSOLID);
             left = tr.fraction;
 
             VectorSet(v, d2, 16, 0);
             G_ProjectSource(self->s.origin, v, v_forward, v_right, right_target);
-            tr = gi.trace(self->s.origin, self->mins, self->maxs, right_target, self, MASK_PLAYERSOLID);
+            tr = gi_trace(self->s.origin, self->mins, self->maxs, right_target, self, MASK_PLAYERSOLID);
             right = tr.fraction;
 
             center = (d1 * center) / d2;
@@ -964,7 +964,7 @@ void ai_run(edict_t *self, float dist)
                 if (left < 1) {
                     VectorSet(v, d2 * left * 0.5f, -16, 0);
                     G_ProjectSource(self->s.origin, v, v_forward, v_right, left_target);
-//                  gi.dprintf("incomplete path, go part way and adjust again\n");
+//                  gi_dprintf("incomplete path, go part way and adjust again\n");
                 }
                 VectorCopy(self->monsterinfo.last_sighting, self->monsterinfo.saved_goal);
                 self->monsterinfo.aiflags |= AI_PURSUE_TEMP;
@@ -972,13 +972,13 @@ void ai_run(edict_t *self, float dist)
                 VectorCopy(left_target, self->monsterinfo.last_sighting);
                 VectorSubtract(self->goalentity->s.origin, self->s.origin, v);
                 self->s.angles[YAW] = self->ideal_yaw = vectoyaw(v);
-//              gi.dprintf("adjusted left\n");
+//              gi_dprintf("adjusted left\n");
 //              debug_drawline(self.origin, self.last_sighting, 152);
             } else if (right >= center && right > left) {
                 if (right < 1) {
                     VectorSet(v, d2 * right * 0.5f, 16, 0);
                     G_ProjectSource(self->s.origin, v, v_forward, v_right, right_target);
-//                  gi.dprintf("incomplete path, go part way and adjust again\n");
+//                  gi_dprintf("incomplete path, go part way and adjust again\n");
                 }
                 VectorCopy(self->monsterinfo.last_sighting, self->monsterinfo.saved_goal);
                 self->monsterinfo.aiflags |= AI_PURSUE_TEMP;
@@ -986,11 +986,11 @@ void ai_run(edict_t *self, float dist)
                 VectorCopy(right_target, self->monsterinfo.last_sighting);
                 VectorSubtract(self->goalentity->s.origin, self->s.origin, v);
                 self->s.angles[YAW] = self->ideal_yaw = vectoyaw(v);
-//              gi.dprintf("adjusted right\n");
+//              gi_dprintf("adjusted right\n");
 //              debug_drawline(self.origin, self.last_sighting, 152);
             }
         }
-//      else gi.dprintf("course was fine\n");
+//      else gi_dprintf("course was fine\n");
     }
 
     M_MoveToGoal(self, dist);

--- a/src/baseq2/g_chase.c
+++ b/src/baseq2/g_chase.c
@@ -58,7 +58,7 @@ void UpdateChaseCam(edict_t *ent)
     if (!targ->groundentity)
         o[2] += 16;
 
-    trace = gi.trace(ownerv, vec3_origin, vec3_origin, o, targ, MASK_SOLID);
+    trace = gi_trace(ownerv, vec3_origin, vec3_origin, o, targ, MASK_SOLID);
 
     VectorCopy(trace.endpos, goal);
 
@@ -67,7 +67,7 @@ void UpdateChaseCam(edict_t *ent)
     // pad for floors and ceilings
     VectorCopy(goal, o);
     o[2] += 6;
-    trace = gi.trace(goal, vec3_origin, vec3_origin, o, targ, MASK_SOLID);
+    trace = gi_trace(goal, vec3_origin, vec3_origin, o, targ, MASK_SOLID);
     if (trace.fraction < 1) {
         VectorCopy(trace.endpos, goal);
         goal[2] -= 6;
@@ -75,7 +75,7 @@ void UpdateChaseCam(edict_t *ent)
 
     VectorCopy(goal, o);
     o[2] -= 6;
-    trace = gi.trace(goal, vec3_origin, vec3_origin, o, targ, MASK_SOLID);
+    trace = gi_trace(goal, vec3_origin, vec3_origin, o, targ, MASK_SOLID);
     if (trace.fraction < 1) {
         VectorCopy(trace.endpos, goal);
         goal[2] += 6;
@@ -101,7 +101,7 @@ void UpdateChaseCam(edict_t *ent)
 
     ent->viewheight = 0;
     ent->client->ps.pmove.pm_flags |= PMF_NO_PREDICTION;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 void ChaseNext(edict_t *ent)
@@ -166,5 +166,5 @@ void GetChaseTarget(edict_t *ent)
             return;
         }
     }
-    gi.centerprintf(ent, "No other players to chase.");
+    gi_centerprintf(ent, "No other players to chase.");
 }

--- a/src/baseq2/g_cmds.c
+++ b/src/baseq2/g_cmds.c
@@ -154,20 +154,20 @@ void Cmd_Give_f(edict_t *ent)
     edict_t     *it_ent;
 
     if ((deathmatch->value || coop->value) && !sv_cheats->value) {
-        gi.cprintf(ent, PRINT_HIGH, "You must run the server with '+set cheats 1' to enable this command.\n");
+        gi_cprintf(ent, PRINT_HIGH, "You must run the server with '+set cheats 1' to enable this command.\n");
         return;
     }
 
-    name = gi.args();
+    name = gi_args();
 
     if (Q_stricmp(name, "all") == 0)
         give_all = true;
     else
         give_all = false;
 
-    if (give_all || Q_stricmp(gi.argv(1), "health") == 0) {
-        if (gi.argc() == 3)
-            ent->health = atoi(gi.argv(2));
+    if (give_all || Q_stricmp(gi_argv(1), "health") == 0) {
+        if (gi_argc() == 3)
+            ent->health = atoi(gi_argv(2));
         else
             ent->health = ent->max_health;
         if (!give_all)
@@ -244,24 +244,24 @@ void Cmd_Give_f(edict_t *ent)
 
     it = FindItem(name);
     if (!it) {
-        name = gi.argv(1);
+        name = gi_argv(1);
         it = FindItem(name);
         if (!it) {
-            gi.cprintf(ent, PRINT_HIGH, "unknown item\n");
+            gi_cprintf(ent, PRINT_HIGH, "unknown item\n");
             return;
         }
     }
 
     if (!it->pickup) {
-        gi.cprintf(ent, PRINT_HIGH, "non-pickup item\n");
+        gi_cprintf(ent, PRINT_HIGH, "non-pickup item\n");
         return;
     }
 
     index = ITEM_INDEX(it);
 
     if (it->flags & IT_AMMO) {
-        if (gi.argc() == 3)
-            ent->client->pers.inventory[index] = atoi(gi.argv(2));
+        if (gi_argc() == 3)
+            ent->client->pers.inventory[index] = atoi(gi_argv(2));
         else
             ent->client->pers.inventory[index] += it->quantity;
     } else {
@@ -287,15 +287,15 @@ argv(0) god
 void Cmd_God_f(edict_t *ent)
 {
     if ((deathmatch->value || coop->value) && !sv_cheats->value) {
-        gi.cprintf(ent, PRINT_HIGH, "You must run the server with '+set cheats 1' to enable this command.\n");
+        gi_cprintf(ent, PRINT_HIGH, "You must run the server with '+set cheats 1' to enable this command.\n");
         return;
     }
 
     ent->flags ^= FL_GODMODE;
     if (!(ent->flags & FL_GODMODE))
-        gi.cprintf(ent, PRINT_HIGH, "godmode OFF\n");
+        gi_cprintf(ent, PRINT_HIGH, "godmode OFF\n");
     else
-        gi.cprintf(ent, PRINT_HIGH, "godmode ON\n");
+        gi_cprintf(ent, PRINT_HIGH, "godmode ON\n");
 }
 
 
@@ -311,15 +311,15 @@ argv(0) notarget
 void Cmd_Notarget_f(edict_t *ent)
 {
     if ((deathmatch->value || coop->value) && !sv_cheats->value) {
-        gi.cprintf(ent, PRINT_HIGH, "You must run the server with '+set cheats 1' to enable this command.\n");
+        gi_cprintf(ent, PRINT_HIGH, "You must run the server with '+set cheats 1' to enable this command.\n");
         return;
     }
 
     ent->flags ^= FL_NOTARGET;
     if (!(ent->flags & FL_NOTARGET))
-        gi.cprintf(ent, PRINT_HIGH, "notarget OFF\n");
+        gi_cprintf(ent, PRINT_HIGH, "notarget OFF\n");
     else
-        gi.cprintf(ent, PRINT_HIGH, "notarget ON\n");
+        gi_cprintf(ent, PRINT_HIGH, "notarget ON\n");
 }
 
 
@@ -333,16 +333,16 @@ argv(0) noclip
 void Cmd_Noclip_f(edict_t *ent)
 {
     if ((deathmatch->value || coop->value) && !sv_cheats->value) {
-        gi.cprintf(ent, PRINT_HIGH, "You must run the server with '+set cheats 1' to enable this command.\n");
+        gi_cprintf(ent, PRINT_HIGH, "You must run the server with '+set cheats 1' to enable this command.\n");
         return;
     }
 
     if (ent->movetype == MOVETYPE_NOCLIP) {
         ent->movetype = MOVETYPE_WALK;
-        gi.cprintf(ent, PRINT_HIGH, "noclip OFF\n");
+        gi_cprintf(ent, PRINT_HIGH, "noclip OFF\n");
     } else {
         ent->movetype = MOVETYPE_NOCLIP;
-        gi.cprintf(ent, PRINT_HIGH, "noclip ON\n");
+        gi_cprintf(ent, PRINT_HIGH, "noclip ON\n");
     }
 }
 
@@ -360,19 +360,19 @@ void Cmd_Use_f(edict_t *ent)
     gitem_t     *it;
     char        *s;
 
-    s = gi.args();
+    s = gi_args();
     it = FindItem(s);
     if (!it) {
-        gi.cprintf(ent, PRINT_HIGH, "unknown item: %s\n", s);
+        gi_cprintf(ent, PRINT_HIGH, "unknown item: %s\n", s);
         return;
     }
     if (!it->use) {
-        gi.cprintf(ent, PRINT_HIGH, "Item is not usable.\n");
+        gi_cprintf(ent, PRINT_HIGH, "Item is not usable.\n");
         return;
     }
     index = ITEM_INDEX(it);
     if (!ent->client->pers.inventory[index]) {
-        gi.cprintf(ent, PRINT_HIGH, "Out of item: %s\n", s);
+        gi_cprintf(ent, PRINT_HIGH, "Out of item: %s\n", s);
         return;
     }
 
@@ -393,19 +393,19 @@ void Cmd_Drop_f(edict_t *ent)
     gitem_t     *it;
     char        *s;
 
-    s = gi.args();
+    s = gi_args();
     it = FindItem(s);
     if (!it) {
-        gi.cprintf(ent, PRINT_HIGH, "unknown item: %s\n", s);
+        gi_cprintf(ent, PRINT_HIGH, "unknown item: %s\n", s);
         return;
     }
     if (!it->drop) {
-        gi.cprintf(ent, PRINT_HIGH, "Item is not dropable.\n");
+        gi_cprintf(ent, PRINT_HIGH, "Item is not dropable.\n");
         return;
     }
     index = ITEM_INDEX(it);
     if (!ent->client->pers.inventory[index]) {
-        gi.cprintf(ent, PRINT_HIGH, "Out of item: %s\n", s);
+        gi_cprintf(ent, PRINT_HIGH, "Out of item: %s\n", s);
         return;
     }
 
@@ -435,11 +435,11 @@ void Cmd_Inven_f(edict_t *ent)
 
     cl->showinventory = true;
 
-    gi.WriteByte(svc_inventory);
+    gi_WriteByte(svc_inventory);
     for (i = 0 ; i < MAX_ITEMS ; i++) {
-        gi.WriteShort(cl->pers.inventory[i]);
+        gi_WriteShort(cl->pers.inventory[i]);
     }
-    gi.unicast(ent, true);
+    gi_unicast(ent, true);
 }
 
 /*
@@ -454,13 +454,13 @@ void Cmd_InvUse_f(edict_t *ent)
     ValidateSelectedItem(ent);
 
     if (ent->client->pers.selected_item == -1) {
-        gi.cprintf(ent, PRINT_HIGH, "No item to use.\n");
+        gi_cprintf(ent, PRINT_HIGH, "No item to use.\n");
         return;
     }
 
     it = &itemlist[ent->client->pers.selected_item];
     if (!it->use) {
-        gi.cprintf(ent, PRINT_HIGH, "Item is not usable.\n");
+        gi_cprintf(ent, PRINT_HIGH, "Item is not usable.\n");
         return;
     }
     it->use(ent, it);
@@ -575,13 +575,13 @@ void Cmd_InvDrop_f(edict_t *ent)
     ValidateSelectedItem(ent);
 
     if (ent->client->pers.selected_item == -1) {
-        gi.cprintf(ent, PRINT_HIGH, "No item to drop.\n");
+        gi_cprintf(ent, PRINT_HIGH, "No item to drop.\n");
         return;
     }
 
     it = &itemlist[ent->client->pers.selected_item];
     if (!it->drop) {
-        gi.cprintf(ent, PRINT_HIGH, "Item is not dropable.\n");
+        gi_cprintf(ent, PRINT_HIGH, "Item is not dropable.\n");
         return;
     }
     it->drop(ent, it);
@@ -670,7 +670,7 @@ void Cmd_Players_f(edict_t *ent)
         strcat(large, small);
     }
 
-    gi.cprintf(ent, PRINT_HIGH, "%s\n%i players\n", large, count);
+    gi_cprintf(ent, PRINT_HIGH, "%s\n%i players\n", large, count);
 }
 
 /*
@@ -682,7 +682,7 @@ void Cmd_Wave_f(edict_t *ent)
 {
     int     i;
 
-    i = atoi(gi.argv(1));
+    i = atoi(gi_argv(1));
 
     // can't wave when ducked
     if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
@@ -695,28 +695,28 @@ void Cmd_Wave_f(edict_t *ent)
 
     switch (i) {
     case 0:
-        gi.cprintf(ent, PRINT_HIGH, "flipoff\n");
+        gi_cprintf(ent, PRINT_HIGH, "flipoff\n");
         ent->s.frame = FRAME_flip01 - 1;
         ent->client->anim_end = FRAME_flip12;
         break;
     case 1:
-        gi.cprintf(ent, PRINT_HIGH, "salute\n");
+        gi_cprintf(ent, PRINT_HIGH, "salute\n");
         ent->s.frame = FRAME_salute01 - 1;
         ent->client->anim_end = FRAME_salute11;
         break;
     case 2:
-        gi.cprintf(ent, PRINT_HIGH, "taunt\n");
+        gi_cprintf(ent, PRINT_HIGH, "taunt\n");
         ent->s.frame = FRAME_taunt01 - 1;
         ent->client->anim_end = FRAME_taunt17;
         break;
     case 3:
-        gi.cprintf(ent, PRINT_HIGH, "wave\n");
+        gi_cprintf(ent, PRINT_HIGH, "wave\n");
         ent->s.frame = FRAME_wave01 - 1;
         ent->client->anim_end = FRAME_wave11;
         break;
     case 4:
     default:
-        gi.cprintf(ent, PRINT_HIGH, "point\n");
+        gi_cprintf(ent, PRINT_HIGH, "point\n");
         ent->s.frame = FRAME_point01 - 1;
         ent->client->anim_end = FRAME_point12;
         break;
@@ -736,7 +736,7 @@ void Cmd_Say_f(edict_t *ent, bool team, bool arg0)
     char    text[2048];
     gclient_t *cl;
 
-    if (gi.argc() < 2 && !arg0)
+    if (gi_argc() < 2 && !arg0)
         return;
 
     if (!((int)(dmflags->value) & (DF_MODELTEAMS | DF_SKINTEAMS)))
@@ -748,11 +748,11 @@ void Cmd_Say_f(edict_t *ent, bool team, bool arg0)
         Q_snprintf(text, sizeof(text), "%s: ", ent->client->pers.netname);
 
     if (arg0) {
-        strcat(text, gi.argv(0));
+        strcat(text, gi_argv(0));
         strcat(text, " ");
-        strcat(text, gi.args());
+        strcat(text, gi_args());
     } else {
-        p = gi.args();
+        p = gi_args();
 
         if (*p == '"') {
             p++;
@@ -771,7 +771,7 @@ void Cmd_Say_f(edict_t *ent, bool team, bool arg0)
         cl = ent->client;
 
         if (level.time < cl->flood_locktill) {
-            gi.cprintf(ent, PRINT_HIGH, "You can't talk for %d more seconds\n",
+            gi_cprintf(ent, PRINT_HIGH, "You can't talk for %d more seconds\n",
                        (int)(cl->flood_locktill - level.time));
             return;
         }
@@ -781,7 +781,7 @@ void Cmd_Say_f(edict_t *ent, bool team, bool arg0)
         if (cl->flood_when[i] &&
             level.time - cl->flood_when[i] < flood_persecond->value) {
             cl->flood_locktill = level.time + flood_waitdelay->value;
-            gi.cprintf(ent, PRINT_CHAT, "Flood protection:  You can't talk for %d seconds.\n",
+            gi_cprintf(ent, PRINT_CHAT, "Flood protection:  You can't talk for %d seconds.\n",
                        (int)flood_waitdelay->value);
             return;
         }
@@ -791,7 +791,7 @@ void Cmd_Say_f(edict_t *ent, bool team, bool arg0)
     }
 
     if (dedicated->value)
-        gi.cprintf(NULL, PRINT_CHAT, "%s", text);
+        gi_cprintf(NULL, PRINT_CHAT, "%s", text);
 
     for (j = 1; j <= game.maxclients; j++) {
         other = &g_edicts[j];
@@ -803,7 +803,7 @@ void Cmd_Say_f(edict_t *ent, bool team, bool arg0)
             if (!OnSameTeam(ent, other))
                 continue;
         }
-        gi.cprintf(other, PRINT_CHAT, "%s", text);
+        gi_cprintf(other, PRINT_CHAT, "%s", text);
     }
 }
 
@@ -829,12 +829,12 @@ void Cmd_PlayerList_f(edict_t *ent)
                    e2->client->resp.spectator ? " (spectator)" : "");
         if (strlen(text) + strlen(st) > sizeof(text) - 50) {
             sprintf(text + strlen(text), "And more...\n");
-            gi.cprintf(ent, PRINT_HIGH, "%s", text);
+            gi_cprintf(ent, PRINT_HIGH, "%s", text);
             return;
         }
         strcat(text, st);
     }
-    gi.cprintf(ent, PRINT_HIGH, "%s", text);
+    gi_cprintf(ent, PRINT_HIGH, "%s", text);
 }
 
 
@@ -850,7 +850,7 @@ void ClientCommand(edict_t *ent)
     if (!ent->client)
         return;     // not fully in game yet
 
-    cmd = gi.argv(0);
+    cmd = gi_argv(0);
 
     if (Q_stricmp(cmd, "players") == 0) {
         Cmd_Players_f(ent);

--- a/src/baseq2/g_combat.c
+++ b/src/baseq2/g_combat.c
@@ -36,7 +36,7 @@ bool CanDamage(edict_t *targ, edict_t *inflictor)
     if (targ->movetype == MOVETYPE_PUSH) {
         VectorAdd(targ->absmin, targ->absmax, dest);
         VectorScale(dest, 0.5f, dest);
-        trace = gi.trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
+        trace = gi_trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
         if (trace.fraction == 1.0f)
             return true;
         if (trace.ent == targ)
@@ -44,35 +44,35 @@ bool CanDamage(edict_t *targ, edict_t *inflictor)
         return false;
     }
 
-    trace = gi.trace(inflictor->s.origin, vec3_origin, vec3_origin, targ->s.origin, inflictor, MASK_SOLID);
+    trace = gi_trace(inflictor->s.origin, vec3_origin, vec3_origin, targ->s.origin, inflictor, MASK_SOLID);
     if (trace.fraction == 1.0f)
         return true;
 
     VectorCopy(targ->s.origin, dest);
     dest[0] += 15.0f;
     dest[1] += 15.0f;
-    trace = gi.trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
+    trace = gi_trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
     if (trace.fraction == 1.0f)
         return true;
 
     VectorCopy(targ->s.origin, dest);
     dest[0] += 15.0f;
     dest[1] -= 15.0f;
-    trace = gi.trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
+    trace = gi_trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
     if (trace.fraction == 1.0f)
         return true;
 
     VectorCopy(targ->s.origin, dest);
     dest[0] -= 15.0f;
     dest[1] += 15.0f;
-    trace = gi.trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
+    trace = gi_trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
     if (trace.fraction == 1.0f)
         return true;
 
     VectorCopy(targ->s.origin, dest);
     dest[0] -= 15.0f;
     dest[1] -= 15.0f;
-    trace = gi.trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
+    trace = gi_trace(inflictor->s.origin, vec3_origin, vec3_origin, dest, inflictor, MASK_SOLID);
     if (trace.fraction == 1.0f)
         return true;
 
@@ -129,12 +129,12 @@ void SpawnDamage(int type, vec3_t origin, vec3_t normal, int damage)
 {
     if (damage > 255)
         damage = 255;
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(type);
-//  gi.WriteByte (damage);
-    gi.WritePosition(origin);
-    gi.WriteDir(normal);
-    gi.multicast(origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(type);
+//  gi_WriteByte (damage);
+    gi_WritePosition(origin);
+    gi_WriteDir(normal);
+    gi_multicast(origin, MULTICAST_PVS);
 }
 
 
@@ -436,7 +436,7 @@ void T_Damage(edict_t *targ, edict_t *inflictor, edict_t *attacker, vec3_t dir, 
     // check for invincibility
     if ((client && client->invincible_framenum > level.framenum) && !(dflags & DAMAGE_NO_PROTECTION)) {
         if (targ->pain_debounce_framenum < level.framenum) {
-            gi.sound(targ, CHAN_ITEM, gi.soundindex("items/protect4.wav"), 1, ATTN_NORM, 0);
+            gi_sound(targ, CHAN_ITEM, gi_soundindex("items/protect4.wav"), 1, ATTN_NORM, 0);
             targ->pain_debounce_framenum = level.framenum + 2 * BASE_FRAMERATE;
         }
         take = 0;

--- a/src/baseq2/g_func.c
+++ b/src/baseq2/g_func.c
@@ -336,7 +336,7 @@ void plat_hit_top(edict_t *ent)
 {
     if (!(ent->flags & FL_TEAMSLAVE)) {
         if (ent->moveinfo.sound_end)
-            gi.sound(ent, CHAN_NO_PHS_ADD + CHAN_VOICE, ent->moveinfo.sound_end, 1, ATTN_STATIC, 0);
+            gi_sound(ent, CHAN_NO_PHS_ADD + CHAN_VOICE, ent->moveinfo.sound_end, 1, ATTN_STATIC, 0);
         ent->s.sound = 0;
     }
     ent->moveinfo.state = STATE_TOP;
@@ -349,7 +349,7 @@ void plat_hit_bottom(edict_t *ent)
 {
     if (!(ent->flags & FL_TEAMSLAVE)) {
         if (ent->moveinfo.sound_end)
-            gi.sound(ent, CHAN_NO_PHS_ADD + CHAN_VOICE, ent->moveinfo.sound_end, 1, ATTN_STATIC, 0);
+            gi_sound(ent, CHAN_NO_PHS_ADD + CHAN_VOICE, ent->moveinfo.sound_end, 1, ATTN_STATIC, 0);
         ent->s.sound = 0;
     }
     ent->moveinfo.state = STATE_BOTTOM;
@@ -359,7 +359,7 @@ void plat_go_down(edict_t *ent)
 {
     if (!(ent->flags & FL_TEAMSLAVE)) {
         if (ent->moveinfo.sound_start)
-            gi.sound(ent, CHAN_NO_PHS_ADD + CHAN_VOICE, ent->moveinfo.sound_start, 1, ATTN_STATIC, 0);
+            gi_sound(ent, CHAN_NO_PHS_ADD + CHAN_VOICE, ent->moveinfo.sound_start, 1, ATTN_STATIC, 0);
         ent->s.sound = ent->moveinfo.sound_middle;
     }
     ent->moveinfo.state = STATE_DOWN;
@@ -370,7 +370,7 @@ void plat_go_up(edict_t *ent)
 {
     if (!(ent->flags & FL_TEAMSLAVE)) {
         if (ent->moveinfo.sound_start)
-            gi.sound(ent, CHAN_NO_PHS_ADD + CHAN_VOICE, ent->moveinfo.sound_start, 1, ATTN_STATIC, 0);
+            gi_sound(ent, CHAN_NO_PHS_ADD + CHAN_VOICE, ent->moveinfo.sound_start, 1, ATTN_STATIC, 0);
         ent->s.sound = ent->moveinfo.sound_middle;
     }
     ent->moveinfo.state = STATE_UP;
@@ -459,7 +459,7 @@ void plat_spawn_inside_trigger(edict_t *ent)
     VectorCopy(tmin, trigger->mins);
     VectorCopy(tmax, trigger->maxs);
 
-    gi.linkentity(trigger);
+    gi_linkentity(trigger);
 }
 
 
@@ -486,7 +486,7 @@ void SP_func_plat(edict_t *ent)
     ent->solid = SOLID_BSP;
     ent->movetype = MOVETYPE_PUSH;
 
-    gi.setmodel(ent, ent->model);
+    gi_setmodel(ent, ent->model);
 
     ent->blocked = plat_blocked;
 
@@ -527,7 +527,7 @@ void SP_func_plat(edict_t *ent)
         ent->moveinfo.state = STATE_UP;
     } else {
         VectorCopy(ent->pos2, ent->s.origin);
-        gi.linkentity(ent);
+        gi_linkentity(ent);
         ent->moveinfo.state = STATE_BOTTOM;
     }
 
@@ -540,9 +540,9 @@ void SP_func_plat(edict_t *ent)
     VectorCopy(ent->pos2, ent->moveinfo.end_origin);
     VectorCopy(ent->s.angles, ent->moveinfo.end_angles);
 
-    ent->moveinfo.sound_start = gi.soundindex("plats/pt1_strt.wav");
-    ent->moveinfo.sound_middle = gi.soundindex("plats/pt1_mid.wav");
-    ent->moveinfo.sound_end = gi.soundindex("plats/pt1_end.wav");
+    ent->moveinfo.sound_start = gi_soundindex("plats/pt1_strt.wav");
+    ent->moveinfo.sound_middle = gi_soundindex("plats/pt1_mid.wav");
+    ent->moveinfo.sound_end = gi_soundindex("plats/pt1_end.wav");
 }
 
 //====================================================================
@@ -624,8 +624,8 @@ void SP_func_rotating(edict_t *ent)
     if (ent->spawnflags & 128)
         ent->s.effects |= EF_ANIM_ALLFAST;
 
-    gi.setmodel(ent, ent->model);
-    gi.linkentity(ent);
+    gi_setmodel(ent, ent->model);
+    gi_linkentity(ent);
 }
 
 /*
@@ -693,7 +693,7 @@ void button_fire(edict_t *self)
 
     self->moveinfo.state = STATE_UP;
     if (self->moveinfo.sound_start && !(self->flags & FL_TEAMSLAVE))
-        gi.sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_start, 1, ATTN_STATIC, 0);
+        gi_sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_start, 1, ATTN_STATIC, 0);
     Move_Calc(self, self->moveinfo.end_origin, button_wait);
 }
 
@@ -731,10 +731,10 @@ void SP_func_button(edict_t *ent)
     G_SetMovedir(ent->s.angles, ent->movedir);
     ent->movetype = MOVETYPE_STOP;
     ent->solid = SOLID_BSP;
-    gi.setmodel(ent, ent->model);
+    gi_setmodel(ent, ent->model);
 
     if (ent->sounds != 1)
-        ent->moveinfo.sound_start = gi.soundindex("switches/butn2.wav");
+        ent->moveinfo.sound_start = gi_soundindex("switches/butn2.wav");
 
     if (!ent->speed)
         ent->speed = 40;
@@ -776,7 +776,7 @@ void SP_func_button(edict_t *ent)
     VectorCopy(ent->pos2, ent->moveinfo.end_origin);
     VectorCopy(ent->s.angles, ent->moveinfo.end_angles);
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 /*
@@ -819,7 +819,7 @@ void door_use_areaportals(edict_t *self, bool open)
 
     while ((t = G_Find(t, FOFS(targetname), self->target))) {
         if (Q_stricmp(t->classname, "func_areaportal") == 0) {
-            gi.SetAreaPortalState(t->style, open);
+            gi_SetAreaPortalState(t->style, open);
         }
     }
 }
@@ -830,7 +830,7 @@ void door_hit_top(edict_t *self)
 {
     if (!(self->flags & FL_TEAMSLAVE)) {
         if (self->moveinfo.sound_end)
-            gi.sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_end, 1, ATTN_STATIC, 0);
+            gi_sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_end, 1, ATTN_STATIC, 0);
         self->s.sound = 0;
     }
     self->moveinfo.state = STATE_TOP;
@@ -846,7 +846,7 @@ void door_hit_bottom(edict_t *self)
 {
     if (!(self->flags & FL_TEAMSLAVE)) {
         if (self->moveinfo.sound_end)
-            gi.sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_end, 1, ATTN_STATIC, 0);
+            gi_sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_end, 1, ATTN_STATIC, 0);
         self->s.sound = 0;
     }
     self->moveinfo.state = STATE_BOTTOM;
@@ -857,7 +857,7 @@ void door_go_down(edict_t *self)
 {
     if (!(self->flags & FL_TEAMSLAVE)) {
         if (self->moveinfo.sound_start)
-            gi.sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_start, 1, ATTN_STATIC, 0);
+            gi_sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_start, 1, ATTN_STATIC, 0);
         self->s.sound = self->moveinfo.sound_middle;
     }
     if (self->max_health) {
@@ -886,7 +886,7 @@ void door_go_up(edict_t *self, edict_t *activator)
 
     if (!(self->flags & FL_TEAMSLAVE)) {
         if (self->moveinfo.sound_start)
-            gi.sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_start, 1, ATTN_STATIC, 0);
+            gi_sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_start, 1, ATTN_STATIC, 0);
         self->s.sound = self->moveinfo.sound_middle;
     }
     self->moveinfo.state = STATE_UP;
@@ -1011,7 +1011,7 @@ void Think_SpawnDoorTrigger(edict_t *ent)
     other->solid = SOLID_TRIGGER;
     other->movetype = MOVETYPE_NONE;
     other->touch = Touch_DoorTrigger;
-    gi.linkentity(other);
+    gi_linkentity(other);
 
     if (ent->spawnflags & DOOR_START_OPEN)
         door_use_areaportals(ent, true);
@@ -1071,8 +1071,8 @@ void door_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf
         return;
     self->touch_debounce_framenum = level.framenum + 5.0f * BASE_FRAMERATE;
 
-    gi.centerprintf(other, "%s", self->message);
-    gi.sound(other, CHAN_AUTO, gi.soundindex("misc/talk1.wav"), 1, ATTN_NORM, 0);
+    gi_centerprintf(other, "%s", self->message);
+    gi_sound(other, CHAN_AUTO, gi_soundindex("misc/talk1.wav"), 1, ATTN_NORM, 0);
 }
 
 void SP_func_door(edict_t *ent)
@@ -1080,15 +1080,15 @@ void SP_func_door(edict_t *ent)
     vec3_t  abs_movedir;
 
     if (ent->sounds != 1) {
-        ent->moveinfo.sound_start = gi.soundindex("doors/dr1_strt.wav");
-        ent->moveinfo.sound_middle = gi.soundindex("doors/dr1_mid.wav");
-        ent->moveinfo.sound_end = gi.soundindex("doors/dr1_end.wav");
+        ent->moveinfo.sound_start = gi_soundindex("doors/dr1_strt.wav");
+        ent->moveinfo.sound_middle = gi_soundindex("doors/dr1_mid.wav");
+        ent->moveinfo.sound_end = gi_soundindex("doors/dr1_end.wav");
     }
 
     G_SetMovedir(ent->s.angles, ent->movedir);
     ent->movetype = MOVETYPE_PUSH;
     ent->solid = SOLID_BSP;
-    gi.setmodel(ent, ent->model);
+    gi_setmodel(ent, ent->model);
 
     ent->blocked = door_blocked;
     ent->use = door_use;
@@ -1132,7 +1132,7 @@ void SP_func_door(edict_t *ent)
         ent->die = door_killed;
         ent->max_health = ent->health;
     } else if (ent->targetname && ent->message) {
-        gi.soundindex("misc/talk.wav");
+        gi_soundindex("misc/talk.wav");
         ent->touch = door_touch;
     }
 
@@ -1154,7 +1154,7 @@ void SP_func_door(edict_t *ent)
     if (!ent->team)
         ent->teammaster = ent;
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 
     ent->nextthink = level.framenum + 1;
     if (ent->health || ent->targetname)
@@ -1211,7 +1211,7 @@ void SP_func_door_rotating(edict_t *ent)
         VectorNegate(ent->movedir, ent->movedir);
 
     if (!st.distance) {
-        gi.dprintf("%s at %s with no distance set\n", ent->classname, vtos(ent->s.origin));
+        gi_dprintf("%s at %s with no distance set\n", ent->classname, vtos(ent->s.origin));
         st.distance = 90;
     }
 
@@ -1221,7 +1221,7 @@ void SP_func_door_rotating(edict_t *ent)
 
     ent->movetype = MOVETYPE_PUSH;
     ent->solid = SOLID_BSP;
-    gi.setmodel(ent, ent->model);
+    gi_setmodel(ent, ent->model);
 
     ent->blocked = door_blocked;
     ent->use = door_use;
@@ -1239,9 +1239,9 @@ void SP_func_door_rotating(edict_t *ent)
         ent->dmg = 2;
 
     if (ent->sounds != 1) {
-        ent->moveinfo.sound_start = gi.soundindex("doors/dr1_strt.wav");
-        ent->moveinfo.sound_middle = gi.soundindex("doors/dr1_mid.wav");
-        ent->moveinfo.sound_end = gi.soundindex("doors/dr1_end.wav");
+        ent->moveinfo.sound_start = gi_soundindex("doors/dr1_strt.wav");
+        ent->moveinfo.sound_middle = gi_soundindex("doors/dr1_mid.wav");
+        ent->moveinfo.sound_end = gi_soundindex("doors/dr1_end.wav");
     }
 
     // if it starts open, switch the positions
@@ -1259,7 +1259,7 @@ void SP_func_door_rotating(edict_t *ent)
     }
 
     if (ent->targetname && ent->message) {
-        gi.soundindex("misc/talk.wav");
+        gi_soundindex("misc/talk.wav");
         ent->touch = door_touch;
     }
 
@@ -1280,7 +1280,7 @@ void SP_func_door_rotating(edict_t *ent)
     if (!ent->team)
         ent->teammaster = ent;
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 
     ent->nextthink = level.framenum + 1;
     if (ent->health || ent->targetname)
@@ -1312,20 +1312,20 @@ void SP_func_water(edict_t *self)
     G_SetMovedir(self->s.angles, self->movedir);
     self->movetype = MOVETYPE_PUSH;
     self->solid = SOLID_BSP;
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
 
     switch (self->sounds) {
     default:
         break;
 
     case 1: // water
-        self->moveinfo.sound_start = gi.soundindex("world/mov_watr.wav");
-        self->moveinfo.sound_end = gi.soundindex("world/stp_watr.wav");
+        self->moveinfo.sound_start = gi_soundindex("world/mov_watr.wav");
+        self->moveinfo.sound_end = gi_soundindex("world/stp_watr.wav");
         break;
 
     case 2: // lava
-        self->moveinfo.sound_start = gi.soundindex("world/mov_watr.wav");
-        self->moveinfo.sound_end = gi.soundindex("world/stp_watr.wav");
+        self->moveinfo.sound_start = gi_soundindex("world/mov_watr.wav");
+        self->moveinfo.sound_end = gi_soundindex("world/stp_watr.wav");
         break;
     }
 
@@ -1366,7 +1366,7 @@ void SP_func_water(edict_t *self)
 
     self->classname = "func_door";
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -1436,7 +1436,7 @@ void train_wait(edict_t *self)
 
         if (!(self->flags & FL_TEAMSLAVE)) {
             if (self->moveinfo.sound_end)
-                gi.sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_end, 1, ATTN_STATIC, 0);
+                gi_sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_end, 1, ATTN_STATIC, 0);
             self->s.sound = 0;
         }
     } else {
@@ -1454,13 +1454,13 @@ void train_next(edict_t *self)
     first = true;
 again:
     if (!self->target) {
-//      gi.dprintf ("train_next: no next target\n");
+//      gi_dprintf ("train_next: no next target\n");
         return;
     }
 
     ent = G_PickTarget(self->target);
     if (!ent) {
-        gi.dprintf("train_next: bad target %s\n", self->target);
+        gi_dprintf("train_next: bad target %s\n", self->target);
         return;
     }
 
@@ -1469,14 +1469,14 @@ again:
     // check for a teleport path_corner
     if (ent->spawnflags & 1) {
         if (!first) {
-            gi.dprintf("connected teleport path_corners, see %s at %s\n", ent->classname, vtos(ent->s.origin));
+            gi_dprintf("connected teleport path_corners, see %s at %s\n", ent->classname, vtos(ent->s.origin));
             return;
         }
         first = false;
         VectorSubtract(ent->s.origin, self->mins, self->s.origin);
         VectorCopy(self->s.origin, self->s.old_origin);
         self->s.event = EV_OTHER_TELEPORT;
-        gi.linkentity(self);
+        gi_linkentity(self);
         goto again;
     }
 
@@ -1485,7 +1485,7 @@ again:
 
     if (!(self->flags & FL_TEAMSLAVE)) {
         if (self->moveinfo.sound_start)
-            gi.sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_start, 1, ATTN_STATIC, 0);
+            gi_sound(self, CHAN_NO_PHS_ADD + CHAN_VOICE, self->moveinfo.sound_start, 1, ATTN_STATIC, 0);
         self->s.sound = self->moveinfo.sound_middle;
     }
 
@@ -1517,18 +1517,18 @@ void func_train_find(edict_t *self)
     edict_t *ent;
 
     if (!self->target) {
-        gi.dprintf("train_find: no target\n");
+        gi_dprintf("train_find: no target\n");
         return;
     }
     ent = G_PickTarget(self->target);
     if (!ent) {
-        gi.dprintf("train_find: target %s not found\n", self->target);
+        gi_dprintf("train_find: target %s not found\n", self->target);
         return;
     }
     self->target = ent->target;
 
     VectorSubtract(ent->s.origin, self->mins, self->s.origin);
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     // if not triggered, start immediately
     if (!self->targetname)
@@ -1572,10 +1572,10 @@ void SP_func_train(edict_t *self)
             self->dmg = 100;
     }
     self->solid = SOLID_BSP;
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
 
     if (st.noise)
-        self->moveinfo.sound_middle = gi.soundindex(st.noise);
+        self->moveinfo.sound_middle = gi_soundindex(st.noise);
 
     if (!self->speed)
         self->speed = 100;
@@ -1585,7 +1585,7 @@ void SP_func_train(edict_t *self)
 
     self->use = train_use;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     if (self->target) {
         // start trains on the second frame, to make sure their targets have had
@@ -1593,7 +1593,7 @@ void SP_func_train(edict_t *self)
         self->nextthink = level.framenum + 1;
         self->think = func_train_find;
     } else {
-        gi.dprintf("func_train without a target at %s\n", vtos(self->absmin));
+        gi_dprintf("func_train without a target at %s\n", vtos(self->absmin));
     }
 }
 
@@ -1605,18 +1605,18 @@ void trigger_elevator_use(edict_t *self, edict_t *other, edict_t *activator)
     edict_t *target;
 
     if (self->movetarget->nextthink) {
-//      gi.dprintf("elevator busy\n");
+//      gi_dprintf("elevator busy\n");
         return;
     }
 
     if (!other->pathtarget) {
-        gi.dprintf("elevator used with no pathtarget\n");
+        gi_dprintf("elevator used with no pathtarget\n");
         return;
     }
 
     target = G_PickTarget(other->pathtarget);
     if (!target) {
-        gi.dprintf("elevator used with bad pathtarget: %s\n", other->pathtarget);
+        gi_dprintf("elevator used with bad pathtarget: %s\n", other->pathtarget);
         return;
     }
 
@@ -1627,16 +1627,16 @@ void trigger_elevator_use(edict_t *self, edict_t *other, edict_t *activator)
 void trigger_elevator_init(edict_t *self)
 {
     if (!self->target) {
-        gi.dprintf("trigger_elevator has no target\n");
+        gi_dprintf("trigger_elevator has no target\n");
         return;
     }
     self->movetarget = G_PickTarget(self->target);
     if (!self->movetarget) {
-        gi.dprintf("trigger_elevator unable to find target %s\n", self->target);
+        gi_dprintf("trigger_elevator unable to find target %s\n", self->target);
         return;
     }
     if (strcmp(self->movetarget->classname, "func_train") != 0) {
-        gi.dprintf("trigger_elevator target %s is not a train\n", self->target);
+        gi_dprintf("trigger_elevator target %s is not a train\n", self->target);
         return;
     }
 
@@ -1699,7 +1699,7 @@ void SP_func_timer(edict_t *self)
 
     if (self->random >= self->wait) {
         self->random = self->wait - FRAMETIME;
-        gi.dprintf("func_timer at %s has random >= wait\n", vtos(self->s.origin));
+        gi_dprintf("func_timer at %s has random >= wait\n", vtos(self->s.origin));
     }
 
     if (self->spawnflags & 1) {
@@ -1743,9 +1743,9 @@ void SP_func_conveyor(edict_t *self)
 
     self->use = func_conveyor_use;
 
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
     self->solid = SOLID_BSP;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -1859,13 +1859,13 @@ void SP_func_door_secret(edict_t *ent)
     float   width;
     float   length;
 
-    ent->moveinfo.sound_start = gi.soundindex("doors/dr1_strt.wav");
-    ent->moveinfo.sound_middle = gi.soundindex("doors/dr1_mid.wav");
-    ent->moveinfo.sound_end = gi.soundindex("doors/dr1_end.wav");
+    ent->moveinfo.sound_start = gi_soundindex("doors/dr1_strt.wav");
+    ent->moveinfo.sound_middle = gi_soundindex("doors/dr1_mid.wav");
+    ent->moveinfo.sound_end = gi_soundindex("doors/dr1_end.wav");
 
     ent->movetype = MOVETYPE_PUSH;
     ent->solid = SOLID_BSP;
-    gi.setmodel(ent, ent->model);
+    gi_setmodel(ent, ent->model);
 
     ent->blocked = door_secret_blocked;
     ent->use = door_secret_use;
@@ -1906,13 +1906,13 @@ void SP_func_door_secret(edict_t *ent)
         ent->die = door_killed;
         ent->max_health = ent->health;
     } else if (ent->targetname && ent->message) {
-        gi.soundindex("misc/talk.wav");
+        gi_soundindex("misc/talk.wav");
         ent->touch = door_touch;
     }
 
     ent->classname = "func_door";
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 
@@ -1926,7 +1926,7 @@ void use_killbox(edict_t *self, edict_t *other, edict_t *activator)
 
 void SP_func_killbox(edict_t *ent)
 {
-    gi.setmodel(ent, ent->model);
+    gi_setmodel(ent, ent->model);
     ent->use = use_killbox;
     ent->svflags = SVF_NOCLIENT;
 }

--- a/src/baseq2/g_items.c
+++ b/src/baseq2/g_items.c
@@ -132,7 +132,7 @@ void DoRespawn(edict_t *ent)
 
     ent->svflags &= ~SVF_NOCLIENT;
     ent->solid = SOLID_TRIGGER;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 
     // send an effect
     ent->s.event = EV_ITEM_RESPAWN;
@@ -145,7 +145,7 @@ void SetRespawn(edict_t *ent, float delay)
     ent->solid = SOLID_NOT;
     ent->nextthink = level.framenum + delay * BASE_FRAMERATE;
     ent->think = DoRespawn;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 
@@ -340,7 +340,7 @@ void Use_Quad(edict_t *ent, gitem_t *item)
     else
         ent->client->quad_framenum = level.framenum + timeout;
 
-    gi.sound(ent, CHAN_ITEM, gi.soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
+    gi_sound(ent, CHAN_ITEM, gi_soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
 }
 
 //======================================================================
@@ -355,7 +355,7 @@ void Use_Breather(edict_t *ent, gitem_t *item)
     else
         ent->client->breather_framenum = level.framenum + 300;
 
-//  gi.sound(ent, CHAN_ITEM, gi.soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
+//  gi_sound(ent, CHAN_ITEM, gi_soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
 }
 
 //======================================================================
@@ -370,7 +370,7 @@ void Use_Envirosuit(edict_t *ent, gitem_t *item)
     else
         ent->client->enviro_framenum = level.framenum + 300;
 
-//  gi.sound(ent, CHAN_ITEM, gi.soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
+//  gi_sound(ent, CHAN_ITEM, gi_soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
 }
 
 //======================================================================
@@ -385,7 +385,7 @@ void    Use_Invulnerability(edict_t *ent, gitem_t *item)
     else
         ent->client->invincible_framenum = level.framenum + 300;
 
-    gi.sound(ent, CHAN_ITEM, gi.soundindex("items/protect.wav"), 1, ATTN_NORM, 0);
+    gi_sound(ent, CHAN_ITEM, gi_soundindex("items/protect.wav"), 1, ATTN_NORM, 0);
 }
 
 //======================================================================
@@ -396,7 +396,7 @@ void    Use_Silencer(edict_t *ent, gitem_t *item)
     ValidateSelectedItem(ent);
     ent->client->silencer_shots += 30;
 
-//  gi.sound(ent, CHAN_ITEM, gi.soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
+//  gi_sound(ent, CHAN_ITEM, gi_soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
 }
 
 //======================================================================
@@ -503,7 +503,7 @@ void Drop_Ammo(edict_t *ent, gitem_t *item)
         ent->client->pers.weapon->tag == AMMO_GRENADES &&
         item->tag == AMMO_GRENADES &&
         ent->client->pers.inventory[index] - dropped->count <= 0) {
-        gi.cprintf(ent, PRINT_HIGH, "Can't drop current weapon\n");
+        gi_cprintf(ent, PRINT_HIGH, "Can't drop current weapon\n");
         G_FreeEdict(dropped);
         return;
     }
@@ -674,15 +674,15 @@ void Use_PowerArmor(edict_t *ent, gitem_t *item)
 
     if (ent->flags & FL_POWER_ARMOR) {
         ent->flags &= ~FL_POWER_ARMOR;
-        gi.sound(ent, CHAN_AUTO, gi.soundindex("misc/power2.wav"), 1, ATTN_NORM, 0);
+        gi_sound(ent, CHAN_AUTO, gi_soundindex("misc/power2.wav"), 1, ATTN_NORM, 0);
     } else {
         index = ITEM_INDEX(FindItem("cells"));
         if (!ent->client->pers.inventory[index]) {
-            gi.cprintf(ent, PRINT_HIGH, "No cells for power armor.\n");
+            gi_cprintf(ent, PRINT_HIGH, "No cells for power armor.\n");
             return;
         }
         ent->flags |= FL_POWER_ARMOR;
-        gi.sound(ent, CHAN_AUTO, gi.soundindex("misc/power1.wav"), 1, ATTN_NORM, 0);
+        gi_sound(ent, CHAN_AUTO, gi_soundindex("misc/power1.wav"), 1, ATTN_NORM, 0);
     }
 }
 
@@ -737,7 +737,7 @@ void Touch_Item(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
         other->client->bonus_alpha = 0.25f;
 
         // show icon and name on status bar
-        other->client->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(ent->item->icon);
+        other->client->ps.stats[STAT_PICKUP_ICON] = gi_imageindex(ent->item->icon);
         other->client->ps.stats[STAT_PICKUP_STRING] = CS_ITEMS + ITEM_INDEX(ent->item);
         other->client->pickup_msg_framenum = level.framenum + 3.0f * BASE_FRAMERATE;
 
@@ -747,15 +747,15 @@ void Touch_Item(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 
         if (ent->item->pickup == Pickup_Health) {
             if (ent->count == 2)
-                gi.sound(other, CHAN_ITEM, gi.soundindex("items/s_health.wav"), 1, ATTN_NORM, 0);
+                gi_sound(other, CHAN_ITEM, gi_soundindex("items/s_health.wav"), 1, ATTN_NORM, 0);
             else if (ent->count == 10)
-                gi.sound(other, CHAN_ITEM, gi.soundindex("items/n_health.wav"), 1, ATTN_NORM, 0);
+                gi_sound(other, CHAN_ITEM, gi_soundindex("items/n_health.wav"), 1, ATTN_NORM, 0);
             else if (ent->count == 25)
-                gi.sound(other, CHAN_ITEM, gi.soundindex("items/l_health.wav"), 1, ATTN_NORM, 0);
+                gi_sound(other, CHAN_ITEM, gi_soundindex("items/l_health.wav"), 1, ATTN_NORM, 0);
             else // (ent->count == 100)
-                gi.sound(other, CHAN_ITEM, gi.soundindex("items/m_health.wav"), 1, ATTN_NORM, 0);
+                gi_sound(other, CHAN_ITEM, gi_soundindex("items/m_health.wav"), 1, ATTN_NORM, 0);
         } else if (ent->item->pickup_sound) {
-            gi.sound(other, CHAN_ITEM, gi.soundindex(ent->item->pickup_sound), 1, ATTN_NORM, 0);
+            gi_sound(other, CHAN_ITEM, gi_soundindex(ent->item->pickup_sound), 1, ATTN_NORM, 0);
         }
     }
 
@@ -809,7 +809,7 @@ edict_t *Drop_Item(edict_t *ent, gitem_t *item)
     dropped->s.renderfx = RF_GLOW;
     VectorSet(dropped->mins, -15, -15, -15);
     VectorSet(dropped->maxs, 15, 15, 15);
-    gi.setmodel(dropped, dropped->item->world_model);
+    gi_setmodel(dropped, dropped->item->world_model);
     dropped->solid = SOLID_TRIGGER;
     dropped->movetype = MOVETYPE_TOSS;
     dropped->touch = drop_temp_touch;
@@ -821,7 +821,7 @@ edict_t *Drop_Item(edict_t *ent, gitem_t *item)
         AngleVectors(ent->client->v_angle, forward, right, NULL);
         VectorSet(offset, 24, 0, -16);
         G_ProjectSource(ent->s.origin, offset, forward, right, dropped->s.origin);
-        trace = gi.trace(ent->s.origin, dropped->mins, dropped->maxs,
+        trace = gi_trace(ent->s.origin, dropped->mins, dropped->maxs,
                          dropped->s.origin, ent, CONTENTS_SOLID);
         VectorCopy(trace.endpos, dropped->s.origin);
     } else {
@@ -835,7 +835,7 @@ edict_t *Drop_Item(edict_t *ent, gitem_t *item)
     dropped->think = drop_make_touchable;
     dropped->nextthink = level.framenum + 1 * BASE_FRAMERATE;
 
-    gi.linkentity(dropped);
+    gi_linkentity(dropped);
 
     return dropped;
 }
@@ -853,7 +853,7 @@ void Use_Item(edict_t *ent, edict_t *other, edict_t *activator)
         ent->touch = Touch_Item;
     }
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 //======================================================================
@@ -875,9 +875,9 @@ void droptofloor(edict_t *ent)
     VectorCopy(v, ent->maxs);
 
     if (ent->model)
-        gi.setmodel(ent, ent->model);
+        gi_setmodel(ent, ent->model);
     else
-        gi.setmodel(ent, ent->item->world_model);
+        gi_setmodel(ent, ent->item->world_model);
     ent->solid = SOLID_TRIGGER;
     ent->movetype = MOVETYPE_TOSS;
     ent->touch = Touch_Item;
@@ -885,9 +885,9 @@ void droptofloor(edict_t *ent)
     v = tv(0, 0, -128);
     VectorAdd(ent->s.origin, v, dest);
 
-    tr = gi.trace(ent->s.origin, ent->mins, ent->maxs, dest, ent, MASK_SOLID);
+    tr = gi_trace(ent->s.origin, ent->mins, ent->maxs, dest, ent, MASK_SOLID);
     if (tr.startsolid) {
-        gi.dprintf("droptofloor: %s startsolid at %s\n", ent->classname, vtos(ent->s.origin));
+        gi_dprintf("droptofloor: %s startsolid at %s\n", ent->classname, vtos(ent->s.origin));
         G_FreeEdict(ent);
         return;
     }
@@ -920,7 +920,7 @@ void droptofloor(edict_t *ent)
         ent->use = Use_Item;
     }
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 
@@ -944,13 +944,13 @@ void PrecacheItem(gitem_t *it)
         return;
 
     if (it->pickup_sound)
-        gi.soundindex(it->pickup_sound);
+        gi_soundindex(it->pickup_sound);
     if (it->world_model)
-        gi.modelindex(it->world_model);
+        gi_modelindex(it->world_model);
     if (it->view_model)
-        gi.modelindex(it->view_model);
+        gi_modelindex(it->view_model);
     if (it->icon)
-        gi.imageindex(it->icon);
+        gi_imageindex(it->icon);
 
     // parse everything for its ammo
     if (it->ammo && it->ammo[0]) {
@@ -971,7 +971,7 @@ void PrecacheItem(gitem_t *it)
 
         len = s - start;
         if (len >= MAX_QPATH || len < 5)
-            gi.error("PrecacheItem: %s has bad precache string", it->classname);
+            gi_error("PrecacheItem: %s has bad precache string", it->classname);
         memcpy(data, start, len);
         data[len] = 0;
         if (*s)
@@ -979,13 +979,13 @@ void PrecacheItem(gitem_t *it)
 
         // determine type based on extension
         if (!strcmp(data + len - 3, "md2"))
-            gi.modelindex(data);
+            gi_modelindex(data);
         else if (!strcmp(data + len - 3, "sp2"))
-            gi.modelindex(data);
+            gi_modelindex(data);
         else if (!strcmp(data + len - 3, "wav"))
-            gi.soundindex(data);
+            gi_soundindex(data);
         if (!strcmp(data + len - 3, "pcx"))
-            gi.imageindex(data);
+            gi_imageindex(data);
     }
 }
 
@@ -1006,7 +1006,7 @@ void SpawnItem(edict_t *ent, gitem_t *item)
     if (ent->spawnflags) {
         if (strcmp(ent->classname, "key_power_cube") != 0) {
             ent->spawnflags = 0;
-            gi.dprintf("%s at %s has invalid spawnflags set\n", ent->classname, vtos(ent->s.origin));
+            gi_dprintf("%s at %s has invalid spawnflags set\n", ent->classname, vtos(ent->s.origin));
         }
     }
 
@@ -1054,7 +1054,7 @@ void SpawnItem(edict_t *ent, gitem_t *item)
     ent->s.effects = item->world_model_flags;
     ent->s.renderfx = RF_GLOW;
     if (ent->model)
-        gi.modelindex(ent->model);
+        gi_modelindex(ent->model);
 }
 
 //======================================================================
@@ -2055,7 +2055,7 @@ void SP_item_health(edict_t *self)
     self->model = "models/items/healing/medium/tris.md2";
     self->count = 10;
     SpawnItem(self, FindItem("Health"));
-    gi.soundindex("items/n_health.wav");
+    gi_soundindex("items/n_health.wav");
 }
 
 /*QUAKED item_health_small (.3 .3 1) (-16 -16 -16) (16 16 16)
@@ -2071,7 +2071,7 @@ void SP_item_health_small(edict_t *self)
     self->count = 2;
     SpawnItem(self, FindItem("Health"));
     self->style = HEALTH_IGNORE_MAX;
-    gi.soundindex("items/s_health.wav");
+    gi_soundindex("items/s_health.wav");
 }
 
 /*QUAKED item_health_large (.3 .3 1) (-16 -16 -16) (16 16 16)
@@ -2086,7 +2086,7 @@ void SP_item_health_large(edict_t *self)
     self->model = "models/items/healing/large/tris.md2";
     self->count = 25;
     SpawnItem(self, FindItem("Health"));
-    gi.soundindex("items/l_health.wav");
+    gi_soundindex("items/l_health.wav");
 }
 
 /*QUAKED item_health_mega (.3 .3 1) (-16 -16 -16) (16 16 16)
@@ -2101,7 +2101,7 @@ void SP_item_health_mega(edict_t *self)
     self->model = "models/items/mega_h/tris.md2";
     self->count = 100;
     SpawnItem(self, FindItem("Health"));
-    gi.soundindex("items/m_health.wav");
+    gi_soundindex("items/m_health.wav");
     self->style = HEALTH_IGNORE_MAX | HEALTH_TIMED;
 }
 
@@ -2127,7 +2127,7 @@ void SetItemNames(void)
 
     for (i = 0 ; i < game.num_items ; i++) {
         it = &itemlist[i];
-        gi.configstring(CS_ITEMS + i, it->pickup_name);
+        gi_configstring(CS_ITEMS + i, it->pickup_name);
     }
 
     jacket_armor_index = ITEM_INDEX(FindItem("Jacket Armor"));

--- a/src/baseq2/g_local.h
+++ b/src/baseq2/g_local.h
@@ -440,8 +440,7 @@ typedef struct {
 
 extern  game_locals_t   game;
 extern  level_locals_t  level;
-extern  game_import_t   gi;
-extern  game_export_t   globals;
+extern  edict_pool_t    *pool;
 extern  spawn_temp_t    st;
 
 extern  int sm_meat_index;

--- a/src/baseq2/g_misc.c
+++ b/src/baseq2/g_misc.c
@@ -29,8 +29,8 @@ Used to group brushes together just for editor convenience.
 void Use_Areaportal(edict_t *ent, edict_t *other, edict_t *activator)
 {
     ent->count ^= 1;        // toggle state
-//  gi.dprintf ("portalstate: %i = %i\n", ent->style, ent->count);
-    gi.SetAreaPortalState(ent->style, ent->count);
+//  gi_dprintf ("portalstate: %i = %i\n", ent->style, ent->count);
+    gi_SetAreaPortalState(ent->style, ent->count);
 }
 
 /*QUAKED func_areaportal (0 0 0) ?
@@ -108,7 +108,7 @@ void gib_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
     self->touch = NULL;
 
     if (plane) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/fhit3.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/fhit3.wav"), 1, ATTN_NORM, 0);
 
         vectoangles(plane->normal, normal_angles);
         AngleVectors(normal_angles, NULL, right, NULL);
@@ -143,7 +143,7 @@ void ThrowGib(edict_t *self, char *gibname, int damage, int type)
     gib->s.origin[1] = origin[1] + crandom() * size[1];
     gib->s.origin[2] = origin[2] + crandom() * size[2];
 
-    gi.setmodel(gib, gibname);
+    gi_setmodel(gib, gibname);
     gib->solid = SOLID_NOT;
     gib->s.effects |= EF_GIB;
     gib->flags |= FL_NO_KNOCKBACK;
@@ -169,7 +169,7 @@ void ThrowGib(edict_t *self, char *gibname, int damage, int type)
     gib->think = G_FreeEdict;
     gib->nextthink = level.framenum + (10 + random() * 10) * BASE_FRAMERATE;
 
-    gi.linkentity(gib);
+    gi_linkentity(gib);
 }
 
 void ThrowHead(edict_t *self, char *gibname, int damage, int type)
@@ -183,7 +183,7 @@ void ThrowHead(edict_t *self, char *gibname, int damage, int type)
     VectorClear(self->maxs);
 
     self->s.modelindex2 = 0;
-    gi.setmodel(self, gibname);
+    gi_setmodel(self, gibname);
     self->solid = SOLID_NOT;
     self->s.effects |= EF_GIB;
     self->s.effects &= ~EF_FLIES;
@@ -211,7 +211,7 @@ void ThrowHead(edict_t *self, char *gibname, int damage, int type)
     self->think = G_FreeEdict;
     self->nextthink = level.framenum + (10 + random() * 10) * BASE_FRAMERATE;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -230,7 +230,7 @@ void ThrowClientHead(edict_t *self, int damage)
 
     self->s.origin[2] += 32;
     self->s.frame = 0;
-    gi.setmodel(self, gibname);
+    gi_setmodel(self, gibname);
     VectorSet(self->mins, -16, -16, 0);
     VectorSet(self->maxs, 16, 16, 16);
 
@@ -252,7 +252,7 @@ void ThrowClientHead(edict_t *self, int damage)
         self->nextthink = 0;
     }
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -273,7 +273,7 @@ void ThrowDebris(edict_t *self, char *modelname, float speed, vec3_t origin)
 
     chunk = G_Spawn();
     VectorCopy(origin, chunk->s.origin);
-    gi.setmodel(chunk, modelname);
+    gi_setmodel(chunk, modelname);
     v[0] = 100 * crandom();
     v[1] = 100 * crandom();
     v[2] = 100 + 100 * crandom();
@@ -290,16 +290,16 @@ void ThrowDebris(edict_t *self, char *modelname, float speed, vec3_t origin)
     chunk->classname = "debris";
     chunk->takedamage = DAMAGE_YES;
     chunk->die = debris_die;
-    gi.linkentity(chunk);
+    gi_linkentity(chunk);
 }
 
 
 void BecomeExplosion1(edict_t *self)
 {
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_EXPLOSION1);
-    gi.WritePosition(self->s.origin);
-    gi.multicast(self->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_EXPLOSION1);
+    gi_WritePosition(self->s.origin);
+    gi_multicast(self->s.origin, MULTICAST_PVS);
 
     G_FreeEdict(self);
 }
@@ -307,10 +307,10 @@ void BecomeExplosion1(edict_t *self)
 
 void BecomeExplosion2(edict_t *self)
 {
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_EXPLOSION2);
-    gi.WritePosition(self->s.origin);
-    gi.multicast(self->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_EXPLOSION2);
+    gi_WritePosition(self->s.origin);
+    gi_multicast(self->s.origin, MULTICAST_PVS);
 
     G_FreeEdict(self);
 }
@@ -376,7 +376,7 @@ void path_corner_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_
 void SP_path_corner(edict_t *self)
 {
     if (!self->targetname) {
-        gi.dprintf("path_corner with no targetname at %s\n", vtos(self->s.origin));
+        gi_dprintf("path_corner with no targetname at %s\n", vtos(self->s.origin));
         G_FreeEdict(self);
         return;
     }
@@ -386,7 +386,7 @@ void SP_path_corner(edict_t *self)
     VectorSet(self->mins, -8, -8, -8);
     VectorSet(self->maxs, 8, 8, 8);
     self->svflags |= SVF_NOCLIENT;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -406,7 +406,7 @@ void point_combat_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface
         other->target = self->target;
         other->goalentity = other->movetarget = G_PickTarget(other->target);
         if (!other->goalentity) {
-            gi.dprintf("%s at %s target %s does not exist\n", self->classname, vtos(self->s.origin), self->target);
+            gi_dprintf("%s at %s target %s does not exist\n", self->classname, vtos(self->s.origin), self->target);
             other->movetarget = self;
         }
         self->target = NULL;
@@ -452,7 +452,7 @@ void SP_point_combat(edict_t *self)
     VectorSet(self->mins, -8, -8, -16);
     VectorSet(self->maxs, 8, 8, 16);
     self->svflags = SVF_NOCLIENT;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -467,15 +467,15 @@ void TH_viewthing(edict_t *ent)
 
 void SP_viewthing(edict_t *ent)
 {
-    gi.dprintf("viewthing spawned\n");
+    gi_dprintf("viewthing spawned\n");
 
     ent->movetype = MOVETYPE_NONE;
     ent->solid = SOLID_BBOX;
     ent->s.renderfx = RF_FRAMELERP;
     VectorSet(ent->mins, -16, -16, -24);
     VectorSet(ent->maxs, 16, 16, 32);
-    ent->s.modelindex = gi.modelindex("models/objects/banner/tris.md2");
-    gi.linkentity(ent);
+    ent->s.modelindex = gi_modelindex("models/objects/banner/tris.md2");
+    gi_linkentity(ent);
     ent->nextthink = level.framenum + 0.5f * BASE_FRAMERATE;
     ent->think = TH_viewthing;
     return;
@@ -514,10 +514,10 @@ Default _cone value is 10 (used to set size of light for spotlights)
 void light_use(edict_t *self, edict_t *other, edict_t *activator)
 {
     if (self->spawnflags & START_OFF) {
-        gi.configstring(CS_LIGHTS + self->style, "m");
+        gi_configstring(CS_LIGHTS + self->style, "m");
         self->spawnflags &= ~START_OFF;
     } else {
-        gi.configstring(CS_LIGHTS + self->style, "a");
+        gi_configstring(CS_LIGHTS + self->style, "a");
         self->spawnflags |= START_OFF;
     }
 }
@@ -533,9 +533,9 @@ void SP_light(edict_t *self)
     if (self->style >= 32) {
         self->use = light_use;
         if (self->spawnflags & START_OFF)
-            gi.configstring(CS_LIGHTS + self->style, "a");
+            gi_configstring(CS_LIGHTS + self->style, "a");
         else
-            gi.configstring(CS_LIGHTS + self->style, "m");
+            gi_configstring(CS_LIGHTS + self->style, "m");
     }
 }
 
@@ -564,7 +564,7 @@ void func_wall_use(edict_t *self, edict_t *other, edict_t *activator)
         self->solid = SOLID_NOT;
         self->svflags |= SVF_NOCLIENT;
     }
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     if (!(self->spawnflags & 2))
         self->use = NULL;
@@ -573,7 +573,7 @@ void func_wall_use(edict_t *self, edict_t *other, edict_t *activator)
 void SP_func_wall(edict_t *self)
 {
     self->movetype = MOVETYPE_PUSH;
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
 
     if (self->spawnflags & 8)
         self->s.effects |= EF_ANIM_ALL;
@@ -583,20 +583,20 @@ void SP_func_wall(edict_t *self)
     // just a wall
     if ((self->spawnflags & 7) == 0) {
         self->solid = SOLID_BSP;
-        gi.linkentity(self);
+        gi_linkentity(self);
         return;
     }
 
     // it must be TRIGGER_SPAWN
     if (!(self->spawnflags & 1)) {
-//      gi.dprintf("func_wall missing TRIGGER_SPAWN\n");
+//      gi_dprintf("func_wall missing TRIGGER_SPAWN\n");
         self->spawnflags |= 1;
     }
 
     // yell if the spawnflags are odd
     if (self->spawnflags & 4) {
         if (!(self->spawnflags & 2)) {
-            gi.dprintf("func_wall START_ON without TOGGLE\n");
+            gi_dprintf("func_wall START_ON without TOGGLE\n");
             self->spawnflags |= 2;
         }
     }
@@ -608,7 +608,7 @@ void SP_func_wall(edict_t *self)
         self->solid = SOLID_NOT;
         self->svflags |= SVF_NOCLIENT;
     }
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -645,7 +645,7 @@ void func_object_use(edict_t *self, edict_t *other, edict_t *activator)
 
 void SP_func_object(edict_t *self)
 {
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
 
     self->mins[0] += 1;
     self->mins[1] += 1;
@@ -676,7 +676,7 @@ void SP_func_object(edict_t *self)
 
     self->clipmask = MASK_MONSTERSOLID;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -765,7 +765,7 @@ void func_explosive_spawn(edict_t *self, edict_t *other, edict_t *activator)
     self->svflags &= ~SVF_NOCLIENT;
     self->use = NULL;
     KillBox(self);
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void SP_func_explosive(edict_t *self)
@@ -778,10 +778,10 @@ void SP_func_explosive(edict_t *self)
 
     self->movetype = MOVETYPE_PUSH;
 
-    gi.modelindex("models/objects/debris1/tris.md2");
-    gi.modelindex("models/objects/debris2/tris.md2");
+    gi_modelindex("models/objects/debris1/tris.md2");
+    gi_modelindex("models/objects/debris2/tris.md2");
 
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
 
     if (self->spawnflags & 1) {
         self->svflags |= SVF_NOCLIENT;
@@ -805,7 +805,7 @@ void SP_func_explosive(edict_t *self)
         self->takedamage = DAMAGE_YES;
     }
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -923,15 +923,15 @@ void SP_misc_explobox(edict_t *self)
         return;
     }
 
-    gi.modelindex("models/objects/debris1/tris.md2");
-    gi.modelindex("models/objects/debris2/tris.md2");
-    gi.modelindex("models/objects/debris3/tris.md2");
+    gi_modelindex("models/objects/debris1/tris.md2");
+    gi_modelindex("models/objects/debris2/tris.md2");
+    gi_modelindex("models/objects/debris3/tris.md2");
 
     self->solid = SOLID_BBOX;
     self->movetype = MOVETYPE_STEP;
 
     self->model = "models/objects/barrels/tris.md2";
-    self->s.modelindex = gi.modelindex(self->model);
+    self->s.modelindex = gi_modelindex(self->model);
     VectorSet(self->mins, -16, -16, 0);
     VectorSet(self->maxs, 16, 16, 40);
 
@@ -951,7 +951,7 @@ void SP_misc_explobox(edict_t *self)
     self->think = M_droptofloor;
     self->nextthink = level.framenum + 2;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -965,10 +965,10 @@ void SP_misc_explobox(edict_t *self)
 void misc_blackhole_use(edict_t *ent, edict_t *other, edict_t *activator)
 {
     /*
-    gi.WriteByte (svc_temp_entity);
-    gi.WriteByte (TE_BOSSTPORT);
-    gi.WritePosition (ent->s.origin);
-    gi.multicast (ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte (svc_temp_entity);
+    gi_WriteByte (TE_BOSSTPORT);
+    gi_WritePosition (ent->s.origin);
+    gi_multicast (ent->s.origin, MULTICAST_PVS);
     */
     G_FreeEdict(ent);
 }
@@ -989,12 +989,12 @@ void SP_misc_blackhole(edict_t *ent)
     ent->solid = SOLID_NOT;
     VectorSet(ent->mins, -64, -64, 0);
     VectorSet(ent->maxs, 64, 64, 8);
-    ent->s.modelindex = gi.modelindex("models/objects/black/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/objects/black/tris.md2");
     ent->s.renderfx = RF_TRANSLUCENT;
     ent->use = misc_blackhole_use;
     ent->think = misc_blackhole_think;
     ent->nextthink = level.framenum + 2;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 /*QUAKED misc_eastertank (1 .5 0) (-32 -32 -16) (32 32 32)
@@ -1016,11 +1016,11 @@ void SP_misc_eastertank(edict_t *ent)
     ent->solid = SOLID_BBOX;
     VectorSet(ent->mins, -32, -32, -16);
     VectorSet(ent->maxs, 32, 32, 32);
-    ent->s.modelindex = gi.modelindex("models/monsters/tank/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/monsters/tank/tris.md2");
     ent->s.frame = 254;
     ent->think = misc_eastertank_think;
     ent->nextthink = level.framenum + 2;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 /*QUAKED misc_easterchick (1 .5 0) (-32 -32 0) (32 32 32)
@@ -1043,11 +1043,11 @@ void SP_misc_easterchick(edict_t *ent)
     ent->solid = SOLID_BBOX;
     VectorSet(ent->mins, -32, -32, 0);
     VectorSet(ent->maxs, 32, 32, 32);
-    ent->s.modelindex = gi.modelindex("models/monsters/bitch/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/monsters/bitch/tris.md2");
     ent->s.frame = 208;
     ent->think = misc_easterchick_think;
     ent->nextthink = level.framenum + 2;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 /*QUAKED misc_easterchick2 (1 .5 0) (-32 -32 0) (32 32 32)
@@ -1070,11 +1070,11 @@ void SP_misc_easterchick2(edict_t *ent)
     ent->solid = SOLID_BBOX;
     VectorSet(ent->mins, -32, -32, 0);
     VectorSet(ent->maxs, 32, 32, 32);
-    ent->s.modelindex = gi.modelindex("models/monsters/bitch/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/monsters/bitch/tris.md2");
     ent->s.frame = 248;
     ent->think = misc_easterchick2_think;
     ent->nextthink = level.framenum + 2;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 
@@ -1091,14 +1091,14 @@ void commander_body_think(edict_t *self)
         self->nextthink = 0;
 
     if (self->s.frame == 22)
-        gi.sound(self, CHAN_BODY, gi.soundindex("tank/thud.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_BODY, gi_soundindex("tank/thud.wav"), 1, ATTN_NORM, 0);
 }
 
 void commander_body_use(edict_t *self, edict_t *other, edict_t *activator)
 {
     self->think = commander_body_think;
     self->nextthink = level.framenum + 1;
-    gi.sound(self, CHAN_BODY, gi.soundindex("tank/pain.wav"), 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, gi_soundindex("tank/pain.wav"), 1, ATTN_NORM, 0);
 }
 
 void commander_body_drop(edict_t *self)
@@ -1112,17 +1112,17 @@ void SP_monster_commander_body(edict_t *self)
     self->movetype = MOVETYPE_NONE;
     self->solid = SOLID_BBOX;
     self->model = "models/monsters/commandr/tris.md2";
-    self->s.modelindex = gi.modelindex(self->model);
+    self->s.modelindex = gi_modelindex(self->model);
     VectorSet(self->mins, -32, -32, 0);
     VectorSet(self->maxs, 32, 32, 48);
     self->use = commander_body_use;
     self->takedamage = DAMAGE_YES;
     self->flags = FL_GODMODE;
     self->s.renderfx |= RF_FRAMELERP;
-    gi.linkentity(self);
+    gi_linkentity(self);
 
-    gi.soundindex("tank/thud.wav");
-    gi.soundindex("tank/pain.wav");
+    gi_soundindex("tank/thud.wav");
+    gi_soundindex("tank/pain.wav");
 
     self->think = commander_body_drop;
     self->nextthink = level.framenum + 5;
@@ -1143,9 +1143,9 @@ void SP_misc_banner(edict_t *ent)
 {
     ent->movetype = MOVETYPE_NONE;
     ent->solid = SOLID_NOT;
-    ent->s.modelindex = gi.modelindex("models/objects/banner/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/objects/banner/tris.md2");
     ent->s.frame = Q_rand() % 16;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 
     ent->think = misc_banner_think;
     ent->nextthink = level.framenum + 1;
@@ -1161,7 +1161,7 @@ void misc_deadsoldier_die(edict_t *self, edict_t *inflictor, edict_t *attacker, 
     if (self->health > -80)
         return;
 
-    gi.sound(self, CHAN_BODY, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
     for (n = 0; n < 4; n++)
         ThrowGib(self, "models/objects/gibs/sm_meat/tris.md2", damage, GIB_ORGANIC);
     ThrowHead(self, "models/objects/gibs/head2/tris.md2", damage, GIB_ORGANIC);
@@ -1177,7 +1177,7 @@ void SP_misc_deadsoldier(edict_t *ent)
 
     ent->movetype = MOVETYPE_NONE;
     ent->solid = SOLID_BBOX;
-    ent->s.modelindex = gi.modelindex("models/deadbods/dude/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/deadbods/dude/tris.md2");
 
     // Defaults to frame 0
     if (ent->spawnflags & 2)
@@ -1201,7 +1201,7 @@ void SP_misc_deadsoldier(edict_t *ent)
     ent->die = misc_deadsoldier_die;
     ent->monsterinfo.aiflags |= AI_GOOD_GUY;
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 /*QUAKED misc_viper (1 .5 0) (-16 -16 0) (16 16 32)
@@ -1225,7 +1225,7 @@ void misc_viper_use(edict_t *self, edict_t *other, edict_t *activator)
 void SP_misc_viper(edict_t *ent)
 {
     if (!ent->target) {
-        gi.dprintf("misc_viper without a target at %s\n", vtos(ent->absmin));
+        gi_dprintf("misc_viper without a target at %s\n", vtos(ent->absmin));
         G_FreeEdict(ent);
         return;
     }
@@ -1235,7 +1235,7 @@ void SP_misc_viper(edict_t *ent)
 
     ent->movetype = MOVETYPE_PUSH;
     ent->solid = SOLID_NOT;
-    ent->s.modelindex = gi.modelindex("models/ships/viper/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/ships/viper/tris.md2");
     VectorSet(ent->mins, -16, -16, 0);
     VectorSet(ent->maxs, 16, 16, 32);
 
@@ -1245,7 +1245,7 @@ void SP_misc_viper(edict_t *ent)
     ent->svflags |= SVF_NOCLIENT;
     ent->moveinfo.accel = ent->moveinfo.decel = ent->moveinfo.speed = ent->speed;
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 
@@ -1258,8 +1258,8 @@ void SP_misc_bigviper(edict_t *ent)
     ent->solid = SOLID_BBOX;
     VectorSet(ent->mins, -176, -120, -24);
     VectorSet(ent->maxs, 176, 120, 72);
-    ent->s.modelindex = gi.modelindex("models/ships/bigviper/tris.md2");
-    gi.linkentity(ent);
+    ent->s.modelindex = gi_modelindex("models/ships/bigviper/tris.md2");
+    gi_linkentity(ent);
 }
 
 
@@ -1321,7 +1321,7 @@ void SP_misc_viper_bomb(edict_t *self)
     VectorSet(self->mins, -8, -8, -8);
     VectorSet(self->maxs, 8, 8, 8);
 
-    self->s.modelindex = gi.modelindex("models/objects/bomb/tris.md2");
+    self->s.modelindex = gi_modelindex("models/objects/bomb/tris.md2");
 
     if (!self->dmg)
         self->dmg = 1000;
@@ -1329,7 +1329,7 @@ void SP_misc_viper_bomb(edict_t *self)
     self->use = misc_viper_bomb_use;
     self->svflags |= SVF_NOCLIENT;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -1354,7 +1354,7 @@ void misc_strogg_ship_use(edict_t *self, edict_t *other, edict_t *activator)
 void SP_misc_strogg_ship(edict_t *ent)
 {
     if (!ent->target) {
-        gi.dprintf("%s without a target at %s\n", ent->classname, vtos(ent->absmin));
+        gi_dprintf("%s without a target at %s\n", ent->classname, vtos(ent->absmin));
         G_FreeEdict(ent);
         return;
     }
@@ -1364,7 +1364,7 @@ void SP_misc_strogg_ship(edict_t *ent)
 
     ent->movetype = MOVETYPE_PUSH;
     ent->solid = SOLID_NOT;
-    ent->s.modelindex = gi.modelindex("models/ships/strogg1/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/ships/strogg1/tris.md2");
     VectorSet(ent->mins, -16, -16, 0);
     VectorSet(ent->maxs, 16, 16, 32);
 
@@ -1374,7 +1374,7 @@ void SP_misc_strogg_ship(edict_t *ent)
     ent->svflags |= SVF_NOCLIENT;
     ent->moveinfo.accel = ent->moveinfo.decel = ent->moveinfo.speed = ent->speed;
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 
@@ -1400,9 +1400,9 @@ void SP_misc_satellite_dish(edict_t *ent)
     ent->solid = SOLID_BBOX;
     VectorSet(ent->mins, -64, -64, 0);
     VectorSet(ent->maxs, 64, 64, 128);
-    ent->s.modelindex = gi.modelindex("models/objects/satellite/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/objects/satellite/tris.md2");
     ent->use = misc_satellite_dish_use;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 
@@ -1412,8 +1412,8 @@ void SP_light_mine1(edict_t *ent)
 {
     ent->movetype = MOVETYPE_NONE;
     ent->solid = SOLID_BBOX;
-    ent->s.modelindex = gi.modelindex("models/objects/minelite/light1/tris.md2");
-    gi.linkentity(ent);
+    ent->s.modelindex = gi_modelindex("models/objects/minelite/light1/tris.md2");
+    gi_linkentity(ent);
 }
 
 
@@ -1423,8 +1423,8 @@ void SP_light_mine2(edict_t *ent)
 {
     ent->movetype = MOVETYPE_NONE;
     ent->solid = SOLID_BBOX;
-    ent->s.modelindex = gi.modelindex("models/objects/minelite/light2/tris.md2");
-    gi.linkentity(ent);
+    ent->s.modelindex = gi_modelindex("models/objects/minelite/light2/tris.md2");
+    gi_linkentity(ent);
 }
 
 
@@ -1433,7 +1433,7 @@ Intended for use with the target_spawner
 */
 void SP_misc_gib_arm(edict_t *ent)
 {
-    gi.setmodel(ent, "models/objects/gibs/arm/tris.md2");
+    gi_setmodel(ent, "models/objects/gibs/arm/tris.md2");
     ent->solid = SOLID_NOT;
     ent->s.effects |= EF_GIB;
     ent->takedamage = DAMAGE_YES;
@@ -1446,7 +1446,7 @@ void SP_misc_gib_arm(edict_t *ent)
     ent->avelocity[2] = random() * 200;
     ent->think = G_FreeEdict;
     ent->nextthink = level.framenum + 30 * BASE_FRAMERATE;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 /*QUAKED misc_gib_leg (1 0 0) (-8 -8 -8) (8 8 8)
@@ -1454,7 +1454,7 @@ Intended for use with the target_spawner
 */
 void SP_misc_gib_leg(edict_t *ent)
 {
-    gi.setmodel(ent, "models/objects/gibs/leg/tris.md2");
+    gi_setmodel(ent, "models/objects/gibs/leg/tris.md2");
     ent->solid = SOLID_NOT;
     ent->s.effects |= EF_GIB;
     ent->takedamage = DAMAGE_YES;
@@ -1467,7 +1467,7 @@ void SP_misc_gib_leg(edict_t *ent)
     ent->avelocity[2] = random() * 200;
     ent->think = G_FreeEdict;
     ent->nextthink = level.framenum + 30 * BASE_FRAMERATE;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 /*QUAKED misc_gib_head (1 0 0) (-8 -8 -8) (8 8 8)
@@ -1475,7 +1475,7 @@ Intended for use with the target_spawner
 */
 void SP_misc_gib_head(edict_t *ent)
 {
-    gi.setmodel(ent, "models/objects/gibs/head/tris.md2");
+    gi_setmodel(ent, "models/objects/gibs/head/tris.md2");
     ent->solid = SOLID_NOT;
     ent->s.effects |= EF_GIB;
     ent->takedamage = DAMAGE_YES;
@@ -1488,7 +1488,7 @@ void SP_misc_gib_head(edict_t *ent)
     ent->avelocity[2] = random() * 200;
     ent->think = G_FreeEdict;
     ent->nextthink = level.framenum + 30 * BASE_FRAMERATE;
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 //=====================================================
@@ -1501,10 +1501,10 @@ used with target_string (must be on same "team")
 void SP_target_character(edict_t *self)
 {
     self->movetype = MOVETYPE_PUSH;
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
     self->solid = SOLID_BSP;
     self->s.frame = 12;
-    gi.linkentity(self);
+    gi_linkentity(self);
     return;
 }
 
@@ -1670,13 +1670,13 @@ void func_clock_use(edict_t *self, edict_t *other, edict_t *activator)
 void SP_func_clock(edict_t *self)
 {
     if (!self->target) {
-        gi.dprintf("%s with no target at %s\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("%s with no target at %s\n", self->classname, vtos(self->s.origin));
         G_FreeEdict(self);
         return;
     }
 
     if ((self->spawnflags & 2) && (!self->count)) {
-        gi.dprintf("%s with no count at %s\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("%s with no count at %s\n", self->classname, vtos(self->s.origin));
         G_FreeEdict(self);
         return;
     }
@@ -1686,7 +1686,7 @@ void SP_func_clock(edict_t *self)
 
     func_clock_reset(self);
 
-    self->message = gi.TagMalloc(CLOCK_MESSAGE_SIZE, TAG_LEVEL);
+    self->message = gi_TagMalloc(CLOCK_MESSAGE_SIZE, TAG_LEVEL);
 
     self->think = func_clock_think;
 
@@ -1707,12 +1707,12 @@ void teleporter_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t
         return;
     dest = G_Find(NULL, FOFS(targetname), self->target);
     if (!dest) {
-        gi.dprintf("Couldn't find destination\n");
+        gi_dprintf("Couldn't find destination\n");
         return;
     }
 
     // unlink to make sure it can't possibly interfere with KillBox
-    gi.unlinkentity(other);
+    gi_unlinkentity(other);
 
     VectorCopy(dest->s.origin, other->s.origin);
     VectorCopy(dest->s.origin, other->s.old_origin);
@@ -1739,7 +1739,7 @@ void teleporter_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t
     // kill anything at the destination
     KillBox(other);
 
-    gi.linkentity(other);
+    gi_linkentity(other);
 }
 
 /*QUAKED misc_teleporter (1 0 0) (-32 -32 -24) (32 32 -16)
@@ -1750,20 +1750,20 @@ void SP_misc_teleporter(edict_t *ent)
     edict_t     *trig;
 
     if (!ent->target) {
-        gi.dprintf("teleporter without a target.\n");
+        gi_dprintf("teleporter without a target.\n");
         G_FreeEdict(ent);
         return;
     }
 
-    gi.setmodel(ent, "models/objects/dmspot/tris.md2");
+    gi_setmodel(ent, "models/objects/dmspot/tris.md2");
     ent->s.skinnum = 1;
     ent->s.effects = EF_TELEPORTER;
-    ent->s.sound = gi.soundindex("world/amb10.wav");
+    ent->s.sound = gi_soundindex("world/amb10.wav");
     ent->solid = SOLID_BBOX;
 
     VectorSet(ent->mins, -32, -32, -24);
     VectorSet(ent->maxs, 32, 32, -16);
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 
     trig = G_Spawn();
     trig->touch = teleporter_touch;
@@ -1773,7 +1773,7 @@ void SP_misc_teleporter(edict_t *ent)
     VectorCopy(ent->s.origin, trig->s.origin);
     VectorSet(trig->mins, -8, -8, 8);
     VectorSet(trig->maxs, 8, 8, 24);
-    gi.linkentity(trig);
+    gi_linkentity(trig);
 
 }
 
@@ -1782,11 +1782,11 @@ Point teleporters at these.
 */
 void SP_misc_teleporter_dest(edict_t *ent)
 {
-    gi.setmodel(ent, "models/objects/dmspot/tris.md2");
+    gi_setmodel(ent, "models/objects/dmspot/tris.md2");
     ent->s.skinnum = 0;
     ent->solid = SOLID_BBOX;
 //  ent->s.effects |= EF_FLIES;
     VectorSet(ent->mins, -32, -32, -24);
     VectorSet(ent->maxs, 32, 32, -16);
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }

--- a/src/baseq2/g_monster.c
+++ b/src/baseq2/g_monster.c
@@ -30,70 +30,70 @@ void monster_fire_bullet(edict_t *self, vec3_t start, vec3_t dir, int damage, in
 {
     fire_bullet(self, start, dir, damage, kick, hspread, vspread, MOD_UNKNOWN);
 
-    gi.WriteByte(svc_muzzleflash2);
-    gi.WriteShort(self - g_edicts);
-    gi.WriteByte(flashtype);
-    gi.multicast(start, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash2);
+    gi_WriteShort(self - g_edicts);
+    gi_WriteByte(flashtype);
+    gi_multicast(start, MULTICAST_PVS);
 }
 
 void monster_fire_shotgun(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int kick, int hspread, int vspread, int count, int flashtype)
 {
     fire_shotgun(self, start, aimdir, damage, kick, hspread, vspread, count, MOD_UNKNOWN);
 
-    gi.WriteByte(svc_muzzleflash2);
-    gi.WriteShort(self - g_edicts);
-    gi.WriteByte(flashtype);
-    gi.multicast(start, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash2);
+    gi_WriteShort(self - g_edicts);
+    gi_WriteByte(flashtype);
+    gi_multicast(start, MULTICAST_PVS);
 }
 
 void monster_fire_blaster(edict_t *self, vec3_t start, vec3_t dir, int damage, int speed, int flashtype, int effect)
 {
     fire_blaster(self, start, dir, damage, speed, effect, false);
 
-    gi.WriteByte(svc_muzzleflash2);
-    gi.WriteShort(self - g_edicts);
-    gi.WriteByte(flashtype);
-    gi.multicast(start, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash2);
+    gi_WriteShort(self - g_edicts);
+    gi_WriteByte(flashtype);
+    gi_multicast(start, MULTICAST_PVS);
 }
 
 void monster_fire_grenade(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int speed, int flashtype)
 {
     fire_grenade(self, start, aimdir, damage, speed, 2.5f, damage + 40);
 
-    gi.WriteByte(svc_muzzleflash2);
-    gi.WriteShort(self - g_edicts);
-    gi.WriteByte(flashtype);
-    gi.multicast(start, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash2);
+    gi_WriteShort(self - g_edicts);
+    gi_WriteByte(flashtype);
+    gi_multicast(start, MULTICAST_PVS);
 }
 
 void monster_fire_rocket(edict_t *self, vec3_t start, vec3_t dir, int damage, int speed, int flashtype)
 {
     fire_rocket(self, start, dir, damage, speed, damage + 20, damage);
 
-    gi.WriteByte(svc_muzzleflash2);
-    gi.WriteShort(self - g_edicts);
-    gi.WriteByte(flashtype);
-    gi.multicast(start, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash2);
+    gi_WriteShort(self - g_edicts);
+    gi_WriteByte(flashtype);
+    gi_multicast(start, MULTICAST_PVS);
 }
 
 void monster_fire_railgun(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int kick, int flashtype)
 {
     fire_rail(self, start, aimdir, damage, kick);
 
-    gi.WriteByte(svc_muzzleflash2);
-    gi.WriteShort(self - g_edicts);
-    gi.WriteByte(flashtype);
-    gi.multicast(start, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash2);
+    gi_WriteShort(self - g_edicts);
+    gi_WriteByte(flashtype);
+    gi_multicast(start, MULTICAST_PVS);
 }
 
 void monster_fire_bfg(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int speed, int kick, float damage_radius, int flashtype)
 {
     fire_bfg(self, start, aimdir, damage, speed, damage_radius);
 
-    gi.WriteByte(svc_muzzleflash2);
-    gi.WriteShort(self - g_edicts);
-    gi.WriteByte(flashtype);
-    gi.multicast(start, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash2);
+    gi_WriteShort(self - g_edicts);
+    gi_WriteByte(flashtype);
+    gi_multicast(start, MULTICAST_PVS);
 }
 
 
@@ -113,7 +113,7 @@ void M_FliesOn(edict_t *self)
     if (self->waterlevel)
         return;
     self->s.effects |= EF_FLIES;
-    self->s.sound = gi.soundindex("infantry/inflies1.wav");
+    self->s.sound = gi_soundindex("infantry/inflies1.wav");
     self->think = M_FliesOff;
     self->nextthink = level.framenum + 60 * BASE_FRAMERATE;
 }
@@ -154,7 +154,7 @@ void M_CheckGround(edict_t *ent)
     point[1] = ent->s.origin[1];
     point[2] = ent->s.origin[2] - 0.25f;
 
-    trace = gi.trace(ent->s.origin, ent->mins, ent->maxs, point, ent, MASK_MONSTERSOLID);
+    trace = gi_trace(ent->s.origin, ent->mins, ent->maxs, point, ent, MASK_MONSTERSOLID);
 
     // check steepness
     if (trace.plane.normal[2] < 0.7f && !trace.startsolid) {
@@ -186,7 +186,7 @@ void M_CatagorizePosition(edict_t *ent)
     point[0] = ent->s.origin[0];
     point[1] = ent->s.origin[1];
     point[2] = ent->s.origin[2] + ent->mins[2] + 1;
-    cont = gi.pointcontents(point);
+    cont = gi_pointcontents(point);
 
     if (!(cont & MASK_WATER)) {
         ent->waterlevel = 0;
@@ -197,13 +197,13 @@ void M_CatagorizePosition(edict_t *ent)
     ent->watertype = cont;
     ent->waterlevel = 1;
     point[2] += 26;
-    cont = gi.pointcontents(point);
+    cont = gi_pointcontents(point);
     if (!(cont & MASK_WATER))
         return;
 
     ent->waterlevel = 2;
     point[2] += 22;
-    cont = gi.pointcontents(point);
+    cont = gi_pointcontents(point);
     if (cont & MASK_WATER)
         ent->waterlevel = 3;
 }
@@ -245,7 +245,7 @@ void M_WorldEffects(edict_t *ent)
 
     if (ent->waterlevel == 0) {
         if (ent->flags & FL_INWATER) {
-            gi.sound(ent, CHAN_BODY, gi.soundindex("player/watr_out.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_BODY, gi_soundindex("player/watr_out.wav"), 1, ATTN_NORM, 0);
             ent->flags &= ~FL_INWATER;
         }
         return;
@@ -268,13 +268,13 @@ void M_WorldEffects(edict_t *ent)
         if (!(ent->svflags & SVF_DEADMONSTER)) {
             if (ent->watertype & CONTENTS_LAVA)
                 if (random() <= 0.5f)
-                    gi.sound(ent, CHAN_BODY, gi.soundindex("player/lava1.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(ent, CHAN_BODY, gi_soundindex("player/lava1.wav"), 1, ATTN_NORM, 0);
                 else
-                    gi.sound(ent, CHAN_BODY, gi.soundindex("player/lava2.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(ent, CHAN_BODY, gi_soundindex("player/lava2.wav"), 1, ATTN_NORM, 0);
             else if (ent->watertype & CONTENTS_SLIME)
-                gi.sound(ent, CHAN_BODY, gi.soundindex("player/watr_in.wav"), 1, ATTN_NORM, 0);
+                gi_sound(ent, CHAN_BODY, gi_soundindex("player/watr_in.wav"), 1, ATTN_NORM, 0);
             else if (ent->watertype & CONTENTS_WATER)
-                gi.sound(ent, CHAN_BODY, gi.soundindex("player/watr_in.wav"), 1, ATTN_NORM, 0);
+                gi_sound(ent, CHAN_BODY, gi_soundindex("player/watr_in.wav"), 1, ATTN_NORM, 0);
         }
 
         ent->flags |= FL_INWATER;
@@ -292,14 +292,14 @@ void M_droptofloor(edict_t *ent)
     VectorCopy(ent->s.origin, end);
     end[2] -= 256;
 
-    trace = gi.trace(ent->s.origin, ent->mins, ent->maxs, end, ent, MASK_MONSTERSOLID);
+    trace = gi_trace(ent->s.origin, ent->mins, ent->maxs, end, ent, MASK_MONSTERSOLID);
 
     if (trace.fraction == 1 || trace.allsolid)
         return;
 
     VectorCopy(trace.endpos, ent->s.origin);
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
     M_CheckGround(ent);
     M_CatagorizePosition(ent);
 }
@@ -428,7 +428,7 @@ void monster_triggered_spawn(edict_t *self)
     self->movetype = MOVETYPE_STEP;
     self->svflags &= ~SVF_NOCLIENT;
     self->air_finished_framenum = level.framenum + 12 * BASE_FRAMERATE;
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     monster_start_go(self);
 
@@ -499,7 +499,7 @@ bool monster_start(edict_t *self)
     if ((self->spawnflags & 4) && !(self->monsterinfo.aiflags & AI_GOOD_GUY)) {
         self->spawnflags &= ~4;
         self->spawnflags |= 1;
-//      gi.dprintf("fixed spawnflags on %s at %s\n", self->classname, vtos(self->s.origin));
+//      gi_dprintf("fixed spawnflags on %s at %s\n", self->classname, vtos(self->s.origin));
     }
 
     if (!(self->monsterinfo.aiflags & AI_GOOD_GUY))
@@ -525,7 +525,7 @@ bool monster_start(edict_t *self)
     if (st.item) {
         self->item = FindItemByClassname(st.item);
         if (!self->item)
-            gi.dprintf("%s at %s has bad item: %s\n", self->classname, vtos(self->s.origin), st.item);
+            gi_dprintf("%s at %s has bad item: %s\n", self->classname, vtos(self->s.origin), st.item);
     }
 
     // randomize what frame they start on
@@ -560,7 +560,7 @@ void monster_start_go(edict_t *self)
             }
         }
         if (notcombat && self->combattarget)
-            gi.dprintf("%s at %s has target with mixed types\n", self->classname, vtos(self->s.origin));
+            gi_dprintf("%s at %s has target with mixed types\n", self->classname, vtos(self->s.origin));
         if (fixup)
             self->target = NULL;
     }
@@ -572,7 +572,7 @@ void monster_start_go(edict_t *self)
         target = NULL;
         while ((target = G_Find(target, FOFS(targetname), self->combattarget)) != NULL) {
             if (strcmp(target->classname, "point_combat") != 0) {
-                gi.dprintf("%s at (%i %i %i) has a bad combattarget %s : %s at (%i %i %i)\n",
+                gi_dprintf("%s at (%i %i %i) has a bad combattarget %s : %s at (%i %i %i)\n",
                            self->classname, (int)self->s.origin[0], (int)self->s.origin[1], (int)self->s.origin[2],
                            self->combattarget, target->classname, (int)target->s.origin[0], (int)target->s.origin[1],
                            (int)target->s.origin[2]);
@@ -583,7 +583,7 @@ void monster_start_go(edict_t *self)
     if (self->target) {
         self->goalentity = self->movetarget = G_PickTarget(self->target);
         if (!self->movetarget) {
-            gi.dprintf("%s can't find target %s at %s\n", self->classname, self->target, vtos(self->s.origin));
+            gi_dprintf("%s can't find target %s at %s\n", self->classname, self->target, vtos(self->s.origin));
             self->target = NULL;
             self->monsterinfo.pause_framenum = INT_MAX;
             self->monsterinfo.stand(self);
@@ -614,7 +614,7 @@ void walkmonster_start_go(edict_t *self)
 
         if (self->groundentity)
             if (!M_walkmove(self, 0, 0))
-                gi.dprintf("%s in solid at %s\n", self->classname, vtos(self->s.origin));
+                gi_dprintf("%s in solid at %s\n", self->classname, vtos(self->s.origin));
     }
 
     if (!self->yaw_speed)
@@ -637,7 +637,7 @@ void walkmonster_start(edict_t *self)
 void flymonster_start_go(edict_t *self)
 {
     if (!M_walkmove(self, 0, 0))
-        gi.dprintf("%s in solid at %s\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("%s in solid at %s\n", self->classname, vtos(self->s.origin));
 
     if (!self->yaw_speed)
         self->yaw_speed = 10;

--- a/src/baseq2/g_native.c
+++ b/src/baseq2/g_native.c
@@ -1,0 +1,166 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#if __wasm__
+#error This file should not be compiled from a WASM compiler.
+#endif
+
+#define NATIVE_LINKAGE
+#include "g_local.h"
+#include "shared/native.h"
+
+wasm_game_export_t   globals;
+
+// Bring in the exports from elsewhere in the source.
+void InitGame(void);
+void ShutdownGame(void);
+void SpawnEntities(const char *, const char *, const char *);
+void WriteGame(const char *, qboolean);
+void ReadGame(const char *);
+void WriteLevel(const char *);
+void ReadLevel(const char *);
+void ClientThink(edict_t *, usercmd_t *);
+qboolean ClientConnect(edict_t *, char *);
+void ClientUserinfoChanged(edict_t *, char *);
+void ClientDisconnect(edict_t *);
+void ClientBegin(edict_t *);
+void ClientCommand(edict_t *);
+void G_RunFrame(void);
+game_capability_t QueryGameCapability(const char *);
+
+/*
+=================
+GetGameAPI
+
+Returns a pointer to the structure with all entry points
+and global variables
+=================
+*/
+static void GetGameAPI_V3(game_import_t *import)
+{
+    gi_bprintf = import->bprintf;
+    gi_dprintf = import->dprintf;
+    gi_cprintf = import->cprintf;
+    gi_centerprintf = import->centerprintf;
+    gi_sound = import->sound;
+    gi_positioned_sound = import->positioned_sound;
+    
+    gi_configstring = import->configstring;
+
+    gi_error = import->error;
+    
+    gi_modelindex = import->modelindex;
+    gi_soundindex = import->soundindex;
+    gi_imageindex = import->imageindex;
+    
+    gi_trace = import->trace;
+    gi_pointcontents = import->pointcontents;
+    gi_inPVS = import->inPVS;
+    gi_inPHS = import->inPHS;
+    gi_SetAreaPortalState = import->SetAreaPortalState;
+    gi_AreasConnected = import->AreasConnected;
+    
+    gi_linkentity = import->linkentity;
+    gi_unlinkentity = import->unlinkentity;
+    gi_BoxEdicts = import->BoxEdicts;
+    gi_Pmove = import->Pmove;
+    
+    gi_multicast = import->multicast;
+    gi_unicast = import->unicast;
+    gi_WriteChar = import->WriteChar;
+    gi_WriteByte = import->WriteByte;
+    gi_WriteShort = import->WriteShort;
+    gi_WriteLong = import->WriteLong;
+    gi_WriteFloat = import->WriteFloat;
+    gi_WriteString = import->WriteString;
+    gi_WritePosition = import->WritePosition;
+    gi_WriteDir = import->WriteDir;
+    gi_WriteAngle = import->WriteAngle;
+    
+    gi_TagMalloc = import->TagMalloc;
+    gi_TagFree = import->TagFree;
+    gi_FreeTags = import->FreeTags;
+    
+    gi_cvar = import->cvar;
+    gi_cvar_set = import->cvar_set;
+    gi_cvar_forceset = import->cvar_forceset;
+    
+    gi_argc = import->argc;
+    gi_argv = import->argv;
+    gi_args = import->args;
+
+    gi_AddCommandString = import->AddCommandString;
+
+    gi_DebugGraph = import->DebugGraph;
+
+    globals.ge.apiversion = GAME_API_VERSION;
+    globals.ge.Init = InitGame;
+    globals.ge.Shutdown = ShutdownGame;
+    globals.ge.SpawnEntities = SpawnEntities;
+
+    globals.ge.WriteGame = WriteGame;
+    globals.ge.ReadGame = ReadGame;
+    globals.ge.WriteLevel = WriteLevel;
+    globals.ge.ReadLevel = ReadLevel;
+
+    globals.ge.ClientThink = ClientThink;
+    globals.ge.ClientConnect = ClientConnect;
+    globals.ge.ClientUserinfoChanged = ClientUserinfoChanged;
+    globals.ge.ClientDisconnect = ClientDisconnect;
+    globals.ge.ClientBegin = ClientBegin;
+    globals.ge.ClientCommand = ClientCommand;
+
+    globals.ge.RunFrame = G_RunFrame;
+
+    globals.ge.ServerCommand = ServerCommand;
+
+    globals.ge.pool.edict_size = sizeof(edict_t);
+
+    pool = &globals.ge.pool;
+}
+
+static void GetGameAPI_V87(wasm_game_import_t *import)
+{
+    // make sure it's a valid 87 implementation.
+    // returning will fall back to just implementing 3.
+    if (import->gi.DebugGraph != NULL)
+        return;
+
+    // we're only interested in supporting version 87, which
+    // provides only one new ability: a simple query feature
+    // between engine and game. This should allow for anything
+    // that any new API should need in the future.
+    if (import->apiversion != WASM_API_VERSION)
+        return;
+
+    gi_QueryEngineCapability = import->QueryEngineCapability;
+
+    globals.ge.apiversion = WASM_API_VERSION;
+
+    globals.QueryGameCapability = QueryGameCapability;
+}
+
+q_exported game_export_t *GetGameAPI(game_import_t *import)
+{
+    if (!globals.ge.apiversion)
+        GetGameAPI_V3(import);
+    else
+        GetGameAPI_V87((wasm_game_import_t *) import);
+
+    return (game_export_t *) &globals;
+}

--- a/src/baseq2/g_native.c
+++ b/src/baseq2/g_native.c
@@ -67,6 +67,8 @@ static void GetGameAPI_V3(game_import_t *import)
     gi_modelindex = import->modelindex;
     gi_soundindex = import->soundindex;
     gi_imageindex = import->imageindex;
+
+    gi_setmodel = import->setmodel;
     
     gi_trace = import->trace;
     gi_pointcontents = import->pointcontents;

--- a/src/baseq2/g_native.c
+++ b/src/baseq2/g_native.c
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "g_local.h"
 #include "shared/native.h"
 
-wasm_game_export_t   globals;
+game_export_87_t   globals;
 
 // Bring in the exports from elsewhere in the source.
 void InitGame(void);
@@ -136,7 +136,7 @@ static void GetGameAPI_V3(game_import_t *import)
     pool = &globals.ge.pool;
 }
 
-static void GetGameAPI_V87(wasm_game_import_t *import)
+static void GetGameAPI_V87(game_import_87_t *import)
 {
     // make sure it's a valid 87 implementation.
     // returning will fall back to just implementing 3.
@@ -147,12 +147,12 @@ static void GetGameAPI_V87(wasm_game_import_t *import)
     // provides only one new ability: a simple query feature
     // between engine and game. This should allow for anything
     // that any new API should need in the future.
-    if (import->apiversion != WASM_API_VERSION)
+    if (import->apiversion != GAME_API_EXTENDED_VERSION)
         return;
 
     gi_QueryEngineCapability = import->QueryEngineCapability;
 
-    globals.ge.apiversion = WASM_API_VERSION;
+    globals.ge.apiversion = GAME_API_EXTENDED_VERSION;
 
     globals.QueryGameCapability = QueryGameCapability;
 }
@@ -162,7 +162,7 @@ q_exported game_export_t *GetGameAPI(game_import_t *import)
     if (!globals.ge.apiversion)
         GetGameAPI_V3(import);
     else
-        GetGameAPI_V87((wasm_game_import_t *) import);
+        GetGameAPI_V87((game_import_87_t *) import);
 
     return (game_export_t *) &globals;
 }

--- a/src/baseq2/g_spawn.c
+++ b/src/baseq2/g_spawn.c
@@ -343,7 +343,7 @@ void ED_CallSpawn(edict_t *ent)
     int     i;
 
     if (!ent->classname) {
-        gi.dprintf("ED_CallSpawn: NULL classname\n");
+        gi_dprintf("ED_CallSpawn: NULL classname\n");
         return;
     }
 
@@ -366,7 +366,7 @@ void ED_CallSpawn(edict_t *ent)
             return;
         }
     }
-    gi.dprintf("%s doesn't have a spawn function\n", ent->classname);
+    gi_dprintf("%s doesn't have a spawn function\n", ent->classname);
 }
 
 /*
@@ -381,7 +381,7 @@ static char *ED_NewString(const char *string)
 
     l = strlen(string) + 1;
 
-    newb = gi.TagMalloc(l, TAG_LEVEL);
+    newb = gi_TagMalloc(l, TAG_LEVEL);
 
     new_p = newb;
 
@@ -425,7 +425,7 @@ static bool ED_ParseField(const spawn_field_t *fields, const char *key, const ch
                 break;
             case F_VECTOR:
                 if (sscanf(value, "%f %f %f", &vec[0], &vec[1], &vec[2]) != 3) {
-                    gi.dprintf("%s: couldn't parse '%s'\n", __func__, key);
+                    gi_dprintf("%s: couldn't parse '%s'\n", __func__, key);
                     VectorClear(vec);
                 }
                 ((float *)(b + f->ofs))[0] = vec[0];
@@ -478,15 +478,15 @@ void ED_ParseEdict(const char **data, edict_t *ent)
         if (key[0] == '}')
             break;
         if (!*data)
-            gi.error("%s: EOF without closing brace", __func__);
+            gi_error("%s: EOF without closing brace", __func__);
 
         // parse value
         value = COM_Parse(data);
         if (!*data)
-            gi.error("%s: EOF without closing brace", __func__);
+            gi_error("%s: EOF without closing brace", __func__);
 
         if (value[0] == '}')
-            gi.error("%s: closing brace without data", __func__);
+            gi_error("%s: closing brace without data", __func__);
 
         init = true;
 
@@ -497,7 +497,7 @@ void ED_ParseEdict(const char **data, edict_t *ent)
 
         if (!ED_ParseField(spawn_fields, key, value, (byte *)ent)) {
             if (!ED_ParseField(temp_fields, key, value, (byte *)&st)) {
-                gi.dprintf("%s: %s is not a field\n", __func__, key);
+                gi_dprintf("%s: %s is not a field\n", __func__, key);
             }
         }
     }
@@ -525,7 +525,7 @@ void G_FindTeams(void)
 
     c = 0;
     c2 = 0;
-    for (i = 1, e = g_edicts + i ; i < globals.num_edicts ; i++, e++) {
+    for (i = 1, e = g_edicts + i ; i < pool->num_edicts ; i++, e++) {
         if (!e->inuse)
             continue;
         if (!e->team)
@@ -536,7 +536,7 @@ void G_FindTeams(void)
         e->teammaster = e;
         c++;
         c2++;
-        for (j = i + 1, e2 = e + 1 ; j < globals.num_edicts ; j++, e2++) {
+        for (j = i + 1, e2 = e + 1 ; j < pool->num_edicts ; j++, e2++) {
             if (!e2->inuse)
                 continue;
             if (!e2->team)
@@ -553,7 +553,7 @@ void G_FindTeams(void)
         }
     }
 
-    gi.dprintf("%i teams with %i entities\n", c, c2);
+    gi_dprintf("%i teams with %i entities\n", c, c2);
 }
 
 /*
@@ -578,11 +578,11 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
     if (skill_level > 3)
         skill_level = 3;
     if (skill->value != skill_level)
-        gi.cvar_forceset("skill", va("%f", skill_level));
+        gi_cvar_forceset("skill", va("%f", skill_level));
 
     SaveClientData();
 
-    gi.FreeTags(TAG_LEVEL);
+    gi_FreeTags(TAG_LEVEL);
 
     memset(&level, 0, sizeof(level));
     memset(g_edicts, 0, game.maxentities * sizeof(g_edicts[0]));
@@ -604,7 +604,7 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
         if (!entities)
             break;
         if (com_token[0] != '{')
-            gi.error("ED_LoadFromFile: found %s when expecting {", com_token);
+            gi_error("ED_LoadFromFile: found %s when expecting {", com_token);
 
         if (!ent)
             ent = g_edicts;
@@ -642,7 +642,7 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
         ED_CallSpawn(ent);
     }
 
-    gi.dprintf("%i entities inhibited\n", inhibit);
+    gi_dprintf("%i entities inhibited\n", inhibit);
 
 #ifdef DEBUG
     i = 1;
@@ -854,168 +854,168 @@ void SP_worldspawn(edict_t *ent)
     // make some data visible to the server
 
     if (ent->message && ent->message[0]) {
-        gi.configstring(CS_NAME, ent->message);
+        gi_configstring(CS_NAME, ent->message);
         Q_strlcpy(level.level_name, ent->message, sizeof(level.level_name));
     } else
         Q_strlcpy(level.level_name, level.mapname, sizeof(level.level_name));
 
     if (st.sky && st.sky[0])
-        gi.configstring(CS_SKY, st.sky);
+        gi_configstring(CS_SKY, st.sky);
     else
-        gi.configstring(CS_SKY, "unit1_");
+        gi_configstring(CS_SKY, "unit1_");
 
-    gi.configstring(CS_SKYROTATE, va("%f", st.skyrotate));
+    gi_configstring(CS_SKYROTATE, va("%f", st.skyrotate));
 
-    gi.configstring(CS_SKYAXIS, va("%f %f %f",
+    gi_configstring(CS_SKYAXIS, va("%f %f %f",
                                    st.skyaxis[0], st.skyaxis[1], st.skyaxis[2]));
 
-    gi.configstring(CS_CDTRACK, va("%i", ent->sounds));
+    gi_configstring(CS_CDTRACK, va("%i", ent->sounds));
 
-    gi.configstring(CS_MAXCLIENTS, va("%i", (int)(maxclients->value)));
+    gi_configstring(CS_MAXCLIENTS, va("%i", (int)(maxclients->value)));
 
     // status bar program
     if (deathmatch->value)
-        gi.configstring(CS_STATUSBAR, dm_statusbar);
+        gi_configstring(CS_STATUSBAR, dm_statusbar);
     else
-        gi.configstring(CS_STATUSBAR, single_statusbar);
+        gi_configstring(CS_STATUSBAR, single_statusbar);
 
     //---------------
 
 
     // help icon for statusbar
-    gi.imageindex("i_help");
-    level.pic_health = gi.imageindex("i_health");
-    gi.imageindex("help");
-    gi.imageindex("field_3");
+    gi_imageindex("i_help");
+    level.pic_health = gi_imageindex("i_health");
+    gi_imageindex("help");
+    gi_imageindex("field_3");
 
     if (!st.gravity)
-        gi.cvar_set("sv_gravity", "800");
+        gi_cvar_set("sv_gravity", "800");
     else
-        gi.cvar_set("sv_gravity", st.gravity);
+        gi_cvar_set("sv_gravity", st.gravity);
 
-    snd_fry = gi.soundindex("player/fry.wav");  // standing in lava / slime
+    snd_fry = gi_soundindex("player/fry.wav");  // standing in lava / slime
 
     PrecacheItem(FindItem("Blaster"));
 
-    gi.soundindex("player/lava1.wav");
-    gi.soundindex("player/lava2.wav");
+    gi_soundindex("player/lava1.wav");
+    gi_soundindex("player/lava2.wav");
 
-    gi.soundindex("misc/pc_up.wav");
-    gi.soundindex("misc/talk1.wav");
+    gi_soundindex("misc/pc_up.wav");
+    gi_soundindex("misc/talk1.wav");
 
-    gi.soundindex("misc/udeath.wav");
+    gi_soundindex("misc/udeath.wav");
 
     // gibs
-    gi.soundindex("items/respawn1.wav");
+    gi_soundindex("items/respawn1.wav");
 
     // sexed sounds
-    gi.soundindex("*death1.wav");
-    gi.soundindex("*death2.wav");
-    gi.soundindex("*death3.wav");
-    gi.soundindex("*death4.wav");
-    gi.soundindex("*fall1.wav");
-    gi.soundindex("*fall2.wav");
-    gi.soundindex("*gurp1.wav");        // drowning damage
-    gi.soundindex("*gurp2.wav");
-    gi.soundindex("*jump1.wav");        // player jump
-    gi.soundindex("*pain25_1.wav");
-    gi.soundindex("*pain25_2.wav");
-    gi.soundindex("*pain50_1.wav");
-    gi.soundindex("*pain50_2.wav");
-    gi.soundindex("*pain75_1.wav");
-    gi.soundindex("*pain75_2.wav");
-    gi.soundindex("*pain100_1.wav");
-    gi.soundindex("*pain100_2.wav");
+    gi_soundindex("*death1.wav");
+    gi_soundindex("*death2.wav");
+    gi_soundindex("*death3.wav");
+    gi_soundindex("*death4.wav");
+    gi_soundindex("*fall1.wav");
+    gi_soundindex("*fall2.wav");
+    gi_soundindex("*gurp1.wav");        // drowning damage
+    gi_soundindex("*gurp2.wav");
+    gi_soundindex("*jump1.wav");        // player jump
+    gi_soundindex("*pain25_1.wav");
+    gi_soundindex("*pain25_2.wav");
+    gi_soundindex("*pain50_1.wav");
+    gi_soundindex("*pain50_2.wav");
+    gi_soundindex("*pain75_1.wav");
+    gi_soundindex("*pain75_2.wav");
+    gi_soundindex("*pain100_1.wav");
+    gi_soundindex("*pain100_2.wav");
 
     // sexed models
     // THIS ORDER MUST MATCH THE DEFINES IN g_local.h
     // you can add more, max 15
-    gi.modelindex("#w_blaster.md2");
-    gi.modelindex("#w_shotgun.md2");
-    gi.modelindex("#w_sshotgun.md2");
-    gi.modelindex("#w_machinegun.md2");
-    gi.modelindex("#w_chaingun.md2");
-    gi.modelindex("#a_grenades.md2");
-    gi.modelindex("#w_glauncher.md2");
-    gi.modelindex("#w_rlauncher.md2");
-    gi.modelindex("#w_hyperblaster.md2");
-    gi.modelindex("#w_railgun.md2");
-    gi.modelindex("#w_bfg.md2");
+    gi_modelindex("#w_blaster.md2");
+    gi_modelindex("#w_shotgun.md2");
+    gi_modelindex("#w_sshotgun.md2");
+    gi_modelindex("#w_machinegun.md2");
+    gi_modelindex("#w_chaingun.md2");
+    gi_modelindex("#a_grenades.md2");
+    gi_modelindex("#w_glauncher.md2");
+    gi_modelindex("#w_rlauncher.md2");
+    gi_modelindex("#w_hyperblaster.md2");
+    gi_modelindex("#w_railgun.md2");
+    gi_modelindex("#w_bfg.md2");
 
     //-------------------
 
-    gi.soundindex("player/gasp1.wav");      // gasping for air
-    gi.soundindex("player/gasp2.wav");      // head breaking surface, not gasping
+    gi_soundindex("player/gasp1.wav");      // gasping for air
+    gi_soundindex("player/gasp2.wav");      // head breaking surface, not gasping
 
-    gi.soundindex("player/watr_in.wav");    // feet hitting water
-    gi.soundindex("player/watr_out.wav");   // feet leaving water
+    gi_soundindex("player/watr_in.wav");    // feet hitting water
+    gi_soundindex("player/watr_out.wav");   // feet leaving water
 
-    gi.soundindex("player/watr_un.wav");    // head going underwater
+    gi_soundindex("player/watr_un.wav");    // head going underwater
 
-    gi.soundindex("player/u_breath1.wav");
-    gi.soundindex("player/u_breath2.wav");
+    gi_soundindex("player/u_breath1.wav");
+    gi_soundindex("player/u_breath2.wav");
 
-    gi.soundindex("items/pkup.wav");        // bonus item pickup
-    gi.soundindex("world/land.wav");        // landing thud
-    gi.soundindex("misc/h2ohit1.wav");      // landing splash
+    gi_soundindex("items/pkup.wav");        // bonus item pickup
+    gi_soundindex("world/land.wav");        // landing thud
+    gi_soundindex("misc/h2ohit1.wav");      // landing splash
 
-    gi.soundindex("items/damage.wav");
-    gi.soundindex("items/protect.wav");
-    gi.soundindex("items/protect4.wav");
-    gi.soundindex("weapons/noammo.wav");
+    gi_soundindex("items/damage.wav");
+    gi_soundindex("items/protect.wav");
+    gi_soundindex("items/protect4.wav");
+    gi_soundindex("weapons/noammo.wav");
 
-    gi.soundindex("infantry/inflies1.wav");
+    gi_soundindex("infantry/inflies1.wav");
 
-    sm_meat_index = gi.modelindex("models/objects/gibs/sm_meat/tris.md2");
-    gi.modelindex("models/objects/gibs/arm/tris.md2");
-    gi.modelindex("models/objects/gibs/bone/tris.md2");
-    gi.modelindex("models/objects/gibs/bone2/tris.md2");
-    gi.modelindex("models/objects/gibs/chest/tris.md2");
-    gi.modelindex("models/objects/gibs/skull/tris.md2");
-    gi.modelindex("models/objects/gibs/head2/tris.md2");
+    sm_meat_index = gi_modelindex("models/objects/gibs/sm_meat/tris.md2");
+    gi_modelindex("models/objects/gibs/arm/tris.md2");
+    gi_modelindex("models/objects/gibs/bone/tris.md2");
+    gi_modelindex("models/objects/gibs/bone2/tris.md2");
+    gi_modelindex("models/objects/gibs/chest/tris.md2");
+    gi_modelindex("models/objects/gibs/skull/tris.md2");
+    gi_modelindex("models/objects/gibs/head2/tris.md2");
 
 //
 // Setup light animation tables. 'a' is total darkness, 'z' is doublebright.
 //
 
     // 0 normal
-    gi.configstring(CS_LIGHTS + 0, "m");
+    gi_configstring(CS_LIGHTS + 0, "m");
 
     // 1 FLICKER (first variety)
-    gi.configstring(CS_LIGHTS + 1, "mmnmmommommnonmmonqnmmo");
+    gi_configstring(CS_LIGHTS + 1, "mmnmmommommnonmmonqnmmo");
 
     // 2 SLOW STRONG PULSE
-    gi.configstring(CS_LIGHTS + 2, "abcdefghijklmnopqrstuvwxyzyxwvutsrqponmlkjihgfedcba");
+    gi_configstring(CS_LIGHTS + 2, "abcdefghijklmnopqrstuvwxyzyxwvutsrqponmlkjihgfedcba");
 
     // 3 CANDLE (first variety)
-    gi.configstring(CS_LIGHTS + 3, "mmmmmaaaaammmmmaaaaaabcdefgabcdefg");
+    gi_configstring(CS_LIGHTS + 3, "mmmmmaaaaammmmmaaaaaabcdefgabcdefg");
 
     // 4 FAST STROBE
-    gi.configstring(CS_LIGHTS + 4, "mamamamamama");
+    gi_configstring(CS_LIGHTS + 4, "mamamamamama");
 
     // 5 GENTLE PULSE 1
-    gi.configstring(CS_LIGHTS + 5, "jklmnopqrstuvwxyzyxwvutsrqponmlkj");
+    gi_configstring(CS_LIGHTS + 5, "jklmnopqrstuvwxyzyxwvutsrqponmlkj");
 
     // 6 FLICKER (second variety)
-    gi.configstring(CS_LIGHTS + 6, "nmonqnmomnmomomno");
+    gi_configstring(CS_LIGHTS + 6, "nmonqnmomnmomomno");
 
     // 7 CANDLE (second variety)
-    gi.configstring(CS_LIGHTS + 7, "mmmaaaabcdefgmmmmaaaammmaamm");
+    gi_configstring(CS_LIGHTS + 7, "mmmaaaabcdefgmmmmaaaammmaamm");
 
     // 8 CANDLE (third variety)
-    gi.configstring(CS_LIGHTS + 8, "mmmaaammmaaammmabcdefaaaammmmabcdefmmmaaaa");
+    gi_configstring(CS_LIGHTS + 8, "mmmaaammmaaammmabcdefaaaammmmabcdefmmmaaaa");
 
     // 9 SLOW STROBE (fourth variety)
-    gi.configstring(CS_LIGHTS + 9, "aaaaaaaazzzzzzzz");
+    gi_configstring(CS_LIGHTS + 9, "aaaaaaaazzzzzzzz");
 
     // 10 FLUORESCENT FLICKER
-    gi.configstring(CS_LIGHTS + 10, "mmamammmmammamamaaamammma");
+    gi_configstring(CS_LIGHTS + 10, "mmamammmmammamamaaamammma");
 
     // 11 SLOW PULSE NOT FADE TO BLACK
-    gi.configstring(CS_LIGHTS + 11, "abcdefghijklmnopqrrqponmlkjihgfedcba");
+    gi_configstring(CS_LIGHTS + 11, "abcdefghijklmnopqrrqponmlkjihgfedcba");
 
     // styles 32-62 are assigned by the light program for switchable lights
 
     // 63 testing
-    gi.configstring(CS_LIGHTS + 63, "a");
+    gi_configstring(CS_LIGHTS + 63, "a");
 }

--- a/src/baseq2/g_svcmds.c
+++ b/src/baseq2/g_svcmds.c
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 void    Svcmd_Test_f(void)
 {
-    gi.cprintf(NULL, PRINT_HIGH, "Svcmd_Test_f()\n");
+    gi_cprintf(NULL, PRINT_HIGH, "Svcmd_Test_f()\n");
 }
 
 /*
@@ -86,7 +86,7 @@ static bool StringToFilter(char *s, ipfilter_t *f)
 
     for (i = 0 ; i < 4 ; i++) {
         if (*s < '0' || *s > '9') {
-            gi.cprintf(NULL, PRINT_HIGH, "Bad filter address: %s\n", s);
+            gi_cprintf(NULL, PRINT_HIGH, "Bad filter address: %s\n", s);
             return false;
         }
 
@@ -157,8 +157,8 @@ void SVCmd_AddIP_f(void)
 {
     int     i;
 
-    if (gi.argc() < 3) {
-        gi.cprintf(NULL, PRINT_HIGH, "Usage:  addip <ip-mask>\n");
+    if (gi_argc() < 3) {
+        gi_cprintf(NULL, PRINT_HIGH, "Usage:  addip <ip-mask>\n");
         return;
     }
 
@@ -167,13 +167,13 @@ void SVCmd_AddIP_f(void)
             break;      // free spot
     if (i == numipfilters) {
         if (numipfilters == MAX_IPFILTERS) {
-            gi.cprintf(NULL, PRINT_HIGH, "IP filter list is full\n");
+            gi_cprintf(NULL, PRINT_HIGH, "IP filter list is full\n");
             return;
         }
         numipfilters++;
     }
 
-    if (!StringToFilter(gi.argv(2), &ipfilters[i]))
+    if (!StringToFilter(gi_argv(2), &ipfilters[i]))
         ipfilters[i].compare = 0xffffffff;
 }
 
@@ -187,12 +187,12 @@ void SVCmd_RemoveIP_f(void)
     ipfilter_t  f;
     int         i, j;
 
-    if (gi.argc() < 3) {
-        gi.cprintf(NULL, PRINT_HIGH, "Usage:  sv removeip <ip-mask>\n");
+    if (gi_argc() < 3) {
+        gi_cprintf(NULL, PRINT_HIGH, "Usage:  sv removeip <ip-mask>\n");
         return;
     }
 
-    if (!StringToFilter(gi.argv(2), &f))
+    if (!StringToFilter(gi_argv(2), &f))
         return;
 
     for (i = 0 ; i < numipfilters ; i++)
@@ -201,10 +201,10 @@ void SVCmd_RemoveIP_f(void)
             for (j = i + 1 ; j < numipfilters ; j++)
                 ipfilters[j - 1] = ipfilters[j];
             numipfilters--;
-            gi.cprintf(NULL, PRINT_HIGH, "Removed.\n");
+            gi_cprintf(NULL, PRINT_HIGH, "Removed.\n");
             return;
         }
-    gi.cprintf(NULL, PRINT_HIGH, "Didn't find %s.\n", gi.argv(2));
+    gi_cprintf(NULL, PRINT_HIGH, "Didn't find %s.\n", gi_argv(2));
 }
 
 /*
@@ -220,10 +220,10 @@ void SVCmd_ListIP_f(void)
         unsigned u32;
     } b;
 
-    gi.cprintf(NULL, PRINT_HIGH, "Filter list:\n");
+    gi_cprintf(NULL, PRINT_HIGH, "Filter list:\n");
     for (i = 0 ; i < numipfilters ; i++) {
         b.u32 = ipfilters[i].compare;
-        gi.cprintf(NULL, PRINT_HIGH, "%3i.%3i.%3i.%3i\n", b.b[0], b.b[1], b.b[2], b.b[3]);
+        gi_cprintf(NULL, PRINT_HIGH, "%3i.%3i.%3i.%3i\n", b.b[0], b.b[1], b.b[2], b.b[3]);
     }
 }
 
@@ -244,7 +244,7 @@ void SVCmd_WriteIP_f(void)
     int     i;
     cvar_t  *game;
 
-    game = gi.cvar("game", "", 0);
+    game = gi_cvar("game", "", 0);
 
     if (!*game->string)
         len = Q_snprintf(name, sizeof(name), "%s/listip.cfg", GAMEVERSION);
@@ -252,15 +252,15 @@ void SVCmd_WriteIP_f(void)
         len = Q_snprintf(name, sizeof(name), "%s/listip.cfg", game->string);
 
     if (len >= sizeof(name)) {
-        gi.cprintf(NULL, PRINT_HIGH, "File name too long\n");
+        gi_cprintf(NULL, PRINT_HIGH, "File name too long\n");
         return;
     }
 
-    gi.cprintf(NULL, PRINT_HIGH, "Writing %s.\n", name);
+    gi_cprintf(NULL, PRINT_HIGH, "Writing %s.\n", name);
 
     f = fopen(name, "wb");
     if (!f) {
-        gi.cprintf(NULL, PRINT_HIGH, "Couldn't open %s\n", name);
+        gi_cprintf(NULL, PRINT_HIGH, "Couldn't open %s\n", name);
         return;
     }
 
@@ -279,7 +279,7 @@ void SVCmd_WriteIP_f(void)
 ServerCommand
 
 ServerCommand will be called when an "sv" command is issued.
-The game can issue gi.argc() / gi.argv() commands to get the rest
+The game can issue gi_argc() / gi_argv() commands to get the rest
 of the parameters
 =================
 */
@@ -287,7 +287,7 @@ void    ServerCommand(void)
 {
     char    *cmd;
 
-    cmd = gi.argv(1);
+    cmd = gi_argv(1);
     if (Q_stricmp(cmd, "test") == 0)
         Svcmd_Test_f();
     else if (Q_stricmp(cmd, "addip") == 0)
@@ -299,5 +299,5 @@ void    ServerCommand(void)
     else if (Q_stricmp(cmd, "writeip") == 0)
         SVCmd_WriteIP_f();
     else
-        gi.cprintf(NULL, PRINT_HIGH, "Unknown server command \"%s\"\n", cmd);
+        gi_cprintf(NULL, PRINT_HIGH, "Unknown server command \"%s\"\n", cmd);
 }

--- a/src/baseq2/g_target.c
+++ b/src/baseq2/g_target.c
@@ -23,10 +23,10 @@ Fire an origin based temp entity event to the clients.
 */
 void Use_Target_Tent(edict_t *ent, edict_t *other, edict_t *activator)
 {
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(ent->style);
-    gi.WritePosition(ent->s.origin);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(ent->style);
+    gi_WritePosition(ent->s.origin);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 }
 
 void SP_target_temp_entity(edict_t *ent)
@@ -71,7 +71,7 @@ void Use_Target_Speaker(edict_t *ent, edict_t *other, edict_t *activator)
             chan = CHAN_VOICE;
         // use a positioned_sound, because this entity won't normally be
         // sent to any clients because it is invisible
-        gi.positioned_sound(ent->s.origin, ent, chan, ent->noise_index, ent->volume, ent->attenuation, 0);
+        gi_positioned_sound(ent->s.origin, ent, chan, ent->noise_index, ent->volume, ent->attenuation, 0);
     }
 }
 
@@ -80,14 +80,14 @@ void SP_target_speaker(edict_t *ent)
     char    buffer[MAX_QPATH];
 
     if (!st.noise) {
-        gi.dprintf("target_speaker with no noise set at %s\n", vtos(ent->s.origin));
+        gi_dprintf("target_speaker with no noise set at %s\n", vtos(ent->s.origin));
         return;
     }
     if (!strstr(st.noise, ".wav"))
         Q_snprintf(buffer, sizeof(buffer), "%s.wav", st.noise);
     else
         Q_strlcpy(buffer, st.noise, sizeof(buffer));
-    ent->noise_index = gi.soundindex(buffer);
+    ent->noise_index = gi_soundindex(buffer);
 
     if (!ent->volume)
         ent->volume = 1.0f;
@@ -105,7 +105,7 @@ void SP_target_speaker(edict_t *ent)
 
     // must link the entity so we get areas and clusters so
     // the server can determine who to send updates to
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 }
 
 
@@ -133,7 +133,7 @@ void SP_target_help(edict_t *ent)
     }
 
     if (!ent->message) {
-        gi.dprintf("%s with no message at %s\n", ent->classname, vtos(ent->s.origin));
+        gi_dprintf("%s with no message at %s\n", ent->classname, vtos(ent->s.origin));
         G_FreeEdict(ent);
         return;
     }
@@ -148,7 +148,7 @@ These are single use targets.
 */
 void use_target_secret(edict_t *ent, edict_t *other, edict_t *activator)
 {
-    gi.sound(ent, CHAN_VOICE, ent->noise_index, 1, ATTN_NORM, 0);
+    gi_sound(ent, CHAN_VOICE, ent->noise_index, 1, ATTN_NORM, 0);
 
     level.found_secrets++;
 
@@ -167,7 +167,7 @@ void SP_target_secret(edict_t *ent)
     ent->use = use_target_secret;
     if (!st.noise)
         st.noise = "misc/secret.wav";
-    ent->noise_index = gi.soundindex(st.noise);
+    ent->noise_index = gi_soundindex(st.noise);
     ent->svflags = SVF_NOCLIENT;
     level.total_secrets++;
     // map bug hack
@@ -183,12 +183,12 @@ These are single use targets.
 */
 void use_target_goal(edict_t *ent, edict_t *other, edict_t *activator)
 {
-    gi.sound(ent, CHAN_VOICE, ent->noise_index, 1, ATTN_NORM, 0);
+    gi_sound(ent, CHAN_VOICE, ent->noise_index, 1, ATTN_NORM, 0);
 
     level.found_goals++;
 
     if (level.found_goals == level.total_goals)
-        gi.configstring(CS_CDTRACK, "0");
+        gi_configstring(CS_CDTRACK, "0");
 
     G_UseTargets(ent, activator);
     G_FreeEdict(ent);
@@ -205,7 +205,7 @@ void SP_target_goal(edict_t *ent)
     ent->use = use_target_goal;
     if (!st.noise)
         st.noise = "misc/secret.wav";
-    ent->noise_index = gi.soundindex(st.noise);
+    ent->noise_index = gi_soundindex(st.noise);
     ent->svflags = SVF_NOCLIENT;
     level.total_goals++;
 }
@@ -223,10 +223,10 @@ void target_explosion_explode(edict_t *self)
 {
     float       save;
 
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_EXPLOSION1);
-    gi.WritePosition(self->s.origin);
-    gi.multicast(self->s.origin, MULTICAST_PHS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_EXPLOSION1);
+    gi_WritePosition(self->s.origin);
+    gi_multicast(self->s.origin, MULTICAST_PHS);
 
     T_RadiusDamage(self, self->activator, self->dmg, NULL, self->dmg + 40, MOD_EXPLOSIVE);
 
@@ -280,7 +280,7 @@ void use_target_changelevel(edict_t *self, edict_t *other, edict_t *activator)
     // if multiplayer, let everyone know who hit the exit
     if (deathmatch->value) {
         if (activator && activator->client)
-            gi.bprintf(PRINT_HIGH, "%s exited the level.\n", activator->client->pers.netname);
+            gi_bprintf(PRINT_HIGH, "%s exited the level.\n", activator->client->pers.netname);
     }
 
     // if going to a new unit, clear cross triggers
@@ -293,7 +293,7 @@ void use_target_changelevel(edict_t *self, edict_t *other, edict_t *activator)
 void SP_target_changelevel(edict_t *ent)
 {
     if (!ent->map) {
-        gi.dprintf("target_changelevel with no map at %s\n", vtos(ent->s.origin));
+        gi_dprintf("target_changelevel with no map at %s\n", vtos(ent->s.origin));
         G_FreeEdict(ent);
         return;
     }
@@ -327,13 +327,13 @@ Set "sounds" to one of the following:
 
 void use_target_splash(edict_t *self, edict_t *other, edict_t *activator)
 {
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_SPLASH);
-    gi.WriteByte(self->count);
-    gi.WritePosition(self->s.origin);
-    gi.WriteDir(self->movedir);
-    gi.WriteByte(self->sounds);
-    gi.multicast(self->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_SPLASH);
+    gi_WriteByte(self->count);
+    gi_WritePosition(self->s.origin);
+    gi_WriteDir(self->movedir);
+    gi_WriteByte(self->sounds);
+    gi_multicast(self->s.origin, MULTICAST_PVS);
 
     if (self->dmg)
         T_RadiusDamage(self, activator, self->dmg, NULL, self->dmg + 40, MOD_SPLASH);
@@ -376,9 +376,9 @@ void use_target_spawner(edict_t *self, edict_t *other, edict_t *activator)
     VectorCopy(self->s.origin, ent->s.origin);
     VectorCopy(self->s.angles, ent->s.angles);
     ED_CallSpawn(ent);
-    gi.unlinkentity(ent);
+    gi_unlinkentity(ent);
     KillBox(ent);
-    gi.linkentity(ent);
+    gi_linkentity(ent);
     if (self->speed)
         VectorCopy(self->movedir, ent->velocity);
 }
@@ -416,14 +416,14 @@ void use_target_blaster(edict_t *self, edict_t *other, edict_t *activator)
 #endif
 
     fire_blaster(self, self->s.origin, self->movedir, self->dmg, self->speed, EF_BLASTER, MOD_TARGET_BLASTER);
-    gi.sound(self, CHAN_VOICE, self->noise_index, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, self->noise_index, 1, ATTN_NORM, 0);
 }
 
 void SP_target_blaster(edict_t *self)
 {
     self->use = use_target_blaster;
     G_SetMovedir(self->s.angles, self->movedir);
-    self->noise_index = gi.soundindex("weapons/laser2.wav");
+    self->noise_index = gi_soundindex("weapons/laser2.wav");
 
     if (!self->dmg)
         self->dmg = 15;
@@ -510,7 +510,7 @@ void target_laser_think(edict_t *self)
     VectorCopy(self->s.origin, start);
     VectorMA(start, 2048, self->movedir, end);
     while (1) {
-        tr = gi.trace(start, NULL, NULL, end, ignore, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_DEADMONSTER);
+        tr = gi_trace(start, NULL, NULL, end, ignore, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_DEADMONSTER);
 
         if (!tr.ent)
             break;
@@ -523,13 +523,13 @@ void target_laser_think(edict_t *self)
         if (!(tr.ent->svflags & SVF_MONSTER) && (!tr.ent->client)) {
             if (self->spawnflags & 0x80000000) {
                 self->spawnflags &= ~0x80000000;
-                gi.WriteByte(svc_temp_entity);
-                gi.WriteByte(TE_LASER_SPARKS);
-                gi.WriteByte(count);
-                gi.WritePosition(tr.endpos);
-                gi.WriteDir(tr.plane.normal);
-                gi.WriteByte(self->s.skinnum);
-                gi.multicast(tr.endpos, MULTICAST_PVS);
+                gi_WriteByte(svc_temp_entity);
+                gi_WriteByte(TE_LASER_SPARKS);
+                gi_WriteByte(count);
+                gi_WritePosition(tr.endpos);
+                gi_WriteDir(tr.plane.normal);
+                gi_WriteByte(self->s.skinnum);
+                gi_multicast(tr.endpos, MULTICAST_PVS);
             }
             break;
         }
@@ -599,7 +599,7 @@ void target_laser_start(edict_t *self)
         if (self->target) {
             ent = G_Find(NULL, FOFS(targetname), self->target);
             if (!ent)
-                gi.dprintf("%s at %s: %s is a bad target\n", self->classname, vtos(self->s.origin), self->target);
+                gi_dprintf("%s at %s: %s is a bad target\n", self->classname, vtos(self->s.origin), self->target);
             self->enemy = ent;
         } else {
             G_SetMovedir(self->s.angles, self->movedir);
@@ -613,7 +613,7 @@ void target_laser_start(edict_t *self)
 
     VectorSet(self->mins, -8, -8, -8);
     VectorSet(self->maxs, 8, 8, 8);
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     if (self->spawnflags & 1)
         target_laser_on(self);
@@ -642,7 +642,7 @@ void target_lightramp_think(edict_t *self)
 
     style[0] = 'a' + self->movedir[0] + diff * self->movedir[2];
     style[1] = 0;
-    gi.configstring(CS_LIGHTS + self->enemy->style, style);
+    gi_configstring(CS_LIGHTS + self->enemy->style, style);
 
     if (diff < self->speed) {
         self->nextthink = level.framenum + 1;
@@ -668,15 +668,15 @@ void target_lightramp_use(edict_t *self, edict_t *other, edict_t *activator)
             if (!e)
                 break;
             if (strcmp(e->classname, "light") != 0) {
-                gi.dprintf("%s at %s ", self->classname, vtos(self->s.origin));
-                gi.dprintf("target %s (%s at %s) is not a light\n", self->target, e->classname, vtos(e->s.origin));
+                gi_dprintf("%s at %s ", self->classname, vtos(self->s.origin));
+                gi_dprintf("target %s (%s at %s) is not a light\n", self->target, e->classname, vtos(e->s.origin));
             } else {
                 self->enemy = e;
             }
         }
 
         if (!self->enemy) {
-            gi.dprintf("%s target %s not found at %s\n", self->classname, self->target, vtos(self->s.origin));
+            gi_dprintf("%s target %s not found at %s\n", self->classname, self->target, vtos(self->s.origin));
             G_FreeEdict(self);
             return;
         }
@@ -689,7 +689,7 @@ void target_lightramp_use(edict_t *self, edict_t *other, edict_t *activator)
 void SP_target_lightramp(edict_t *self)
 {
     if (!self->message || strlen(self->message) != 2 || self->message[0] < 'a' || self->message[0] > 'z' || self->message[1] < 'a' || self->message[1] > 'z' || self->message[0] == self->message[1]) {
-        gi.dprintf("target_lightramp has bad ramp (%s) at %s\n", self->message, vtos(self->s.origin));
+        gi_dprintf("target_lightramp has bad ramp (%s) at %s\n", self->message, vtos(self->s.origin));
         G_FreeEdict(self);
         return;
     }
@@ -700,7 +700,7 @@ void SP_target_lightramp(edict_t *self)
     }
 
     if (!self->target) {
-        gi.dprintf("%s with no target at %s\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("%s with no target at %s\n", self->classname, vtos(self->s.origin));
         G_FreeEdict(self);
         return;
     }
@@ -729,11 +729,11 @@ void target_earthquake_think(edict_t *self)
     edict_t *e;
 
     if (self->last_move_framenum < level.framenum) {
-        gi.positioned_sound(self->s.origin, self, CHAN_AUTO, self->noise_index, 1.0f, ATTN_NONE, 0);
+        gi_positioned_sound(self->s.origin, self, CHAN_AUTO, self->noise_index, 1.0f, ATTN_NONE, 0);
         self->last_move_framenum = level.framenum + 0.5f * BASE_FRAMERATE;
     }
 
-    for (i = 1, e = g_edicts + i; i < globals.num_edicts; i++, e++) {
+    for (i = 1, e = g_edicts + i; i < pool->num_edicts; i++, e++) {
         if (!e->inuse)
             continue;
         if (!e->client)
@@ -762,7 +762,7 @@ void target_earthquake_use(edict_t *self, edict_t *other, edict_t *activator)
 void SP_target_earthquake(edict_t *self)
 {
     if (!self->targetname)
-        gi.dprintf("untargeted %s at %s\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("untargeted %s at %s\n", self->classname, vtos(self->s.origin));
 
     if (!self->count)
         self->count = 5;
@@ -774,5 +774,5 @@ void SP_target_earthquake(edict_t *self)
     self->think = target_earthquake_think;
     self->use = target_earthquake_use;
 
-    self->noise_index = gi.soundindex("world/quake.wav");
+    self->noise_index = gi_soundindex("world/quake.wav");
 }

--- a/src/baseq2/g_trigger.c
+++ b/src/baseq2/g_trigger.c
@@ -25,7 +25,7 @@ void InitTrigger(edict_t *self)
 
     self->solid = SOLID_TRIGGER;
     self->movetype = MOVETYPE_NONE;
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
     self->svflags = SVF_NOCLIENT;
 }
 
@@ -103,17 +103,17 @@ void trigger_enable(edict_t *self, edict_t *other, edict_t *activator)
 {
     self->solid = SOLID_TRIGGER;
     self->use = Use_Multi;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void SP_trigger_multiple(edict_t *ent)
 {
     if (ent->sounds == 1)
-        ent->noise_index = gi.soundindex("misc/secret.wav");
+        ent->noise_index = gi_soundindex("misc/secret.wav");
     else if (ent->sounds == 2)
-        ent->noise_index = gi.soundindex("misc/talk.wav");
+        ent->noise_index = gi_soundindex("misc/talk.wav");
     else if (ent->sounds == 3)
-        ent->noise_index = gi.soundindex("misc/trigger1.wav");
+        ent->noise_index = gi_soundindex("misc/trigger1.wav");
 
     if (!ent->wait)
         ent->wait = 0.2f;
@@ -133,8 +133,8 @@ void SP_trigger_multiple(edict_t *ent)
     if (!VectorEmpty(ent->s.angles))
         G_SetMovedir(ent->s.angles, ent->movedir);
 
-    gi.setmodel(ent, ent->model);
-    gi.linkentity(ent);
+    gi_setmodel(ent, ent->model);
+    gi_linkentity(ent);
 }
 
 
@@ -163,7 +163,7 @@ void SP_trigger_once(edict_t *ent)
         VectorMA(ent->mins, 0.5f, ent->size, v);
         ent->spawnflags &= ~1;
         ent->spawnflags |= 4;
-        gi.dprintf("fixed TRIGGERED flag on %s at %s\n", ent->classname, vtos(v));
+        gi_dprintf("fixed TRIGGERED flag on %s at %s\n", ent->classname, vtos(v));
     }
 
     ent->wait = -1;
@@ -210,12 +210,12 @@ void trigger_key_use(edict_t *self, edict_t *other, edict_t *activator)
         if (level.framenum < self->touch_debounce_framenum)
             return;
         self->touch_debounce_framenum = level.framenum + 5.0f * BASE_FRAMERATE;
-        gi.centerprintf(activator, "You need the %s", self->item->pickup_name);
-        gi.sound(activator, CHAN_AUTO, gi.soundindex("misc/keytry.wav"), 1, ATTN_NORM, 0);
+        gi_centerprintf(activator, "You need the %s", self->item->pickup_name);
+        gi_sound(activator, CHAN_AUTO, gi_soundindex("misc/keytry.wav"), 1, ATTN_NORM, 0);
         return;
     }
 
-    gi.sound(activator, CHAN_AUTO, gi.soundindex("misc/keyuse.wav"), 1, ATTN_NORM, 0);
+    gi_sound(activator, CHAN_AUTO, gi_soundindex("misc/keyuse.wav"), 1, ATTN_NORM, 0);
     if (coop->value) {
         int     player;
         edict_t *ent;
@@ -259,23 +259,23 @@ void trigger_key_use(edict_t *self, edict_t *other, edict_t *activator)
 void SP_trigger_key(edict_t *self)
 {
     if (!st.item) {
-        gi.dprintf("no key item for trigger_key at %s\n", vtos(self->s.origin));
+        gi_dprintf("no key item for trigger_key at %s\n", vtos(self->s.origin));
         return;
     }
     self->item = FindItemByClassname(st.item);
 
     if (!self->item) {
-        gi.dprintf("item %s not found for trigger_key at %s\n", st.item, vtos(self->s.origin));
+        gi_dprintf("item %s not found for trigger_key at %s\n", st.item, vtos(self->s.origin));
         return;
     }
 
     if (!self->target) {
-        gi.dprintf("%s at %s has no target\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("%s at %s has no target\n", self->classname, vtos(self->s.origin));
         return;
     }
 
-    gi.soundindex("misc/keytry.wav");
-    gi.soundindex("misc/keyuse.wav");
+    gi_soundindex("misc/keytry.wav");
+    gi_soundindex("misc/keyuse.wav");
 
     self->use = trigger_key_use;
 }
@@ -306,15 +306,15 @@ void trigger_counter_use(edict_t *self, edict_t *other, edict_t *activator)
 
     if (self->count) {
         if (!(self->spawnflags & 1)) {
-            gi.centerprintf(activator, "%i more to go...", self->count);
-            gi.sound(activator, CHAN_AUTO, gi.soundindex("misc/talk1.wav"), 1, ATTN_NORM, 0);
+            gi_centerprintf(activator, "%i more to go...", self->count);
+            gi_sound(activator, CHAN_AUTO, gi_soundindex("misc/talk1.wav"), 1, ATTN_NORM, 0);
         }
         return;
     }
 
     if (!(self->spawnflags & 1)) {
-        gi.centerprintf(activator, "Sequence completed!");
-        gi.sound(activator, CHAN_AUTO, gi.soundindex("misc/talk1.wav"), 1, ATTN_NORM, 0);
+        gi_centerprintf(activator, "Sequence completed!");
+        gi_sound(activator, CHAN_AUTO, gi_soundindex("misc/talk1.wav"), 1, ATTN_NORM, 0);
     }
     self->activator = activator;
     multi_trigger(self);
@@ -374,7 +374,7 @@ void trigger_push_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface
             VectorCopy(other->velocity, other->client->oldvelocity);
             if (other->fly_sound_debounce_framenum < level.framenum) {
                 other->fly_sound_debounce_framenum = level.framenum + 1.5f * BASE_FRAMERATE;
-                gi.sound(other, CHAN_AUTO, windsound, 1, ATTN_NORM, 0);
+                gi_sound(other, CHAN_AUTO, windsound, 1, ATTN_NORM, 0);
             }
         }
     }
@@ -390,11 +390,11 @@ Pushes the player
 void SP_trigger_push(edict_t *self)
 {
     InitTrigger(self);
-    windsound = gi.soundindex("misc/windfly.wav");
+    windsound = gi_soundindex("misc/windfly.wav");
     self->touch = trigger_push_touch;
     if (!self->speed)
         self->speed = 1000;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -424,7 +424,7 @@ void hurt_use(edict_t *self, edict_t *other, edict_t *activator)
         self->solid = SOLID_TRIGGER;
     else
         self->solid = SOLID_NOT;
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     if (!(self->spawnflags & 2))
         self->use = NULL;
@@ -448,7 +448,7 @@ void hurt_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf
 
     if (!(self->spawnflags & 4)) {
         if ((level.framenum % 10) == 0)
-            gi.sound(other, CHAN_AUTO, self->noise_index, 1, ATTN_NORM, 0);
+            gi_sound(other, CHAN_AUTO, self->noise_index, 1, ATTN_NORM, 0);
     }
 
     if (self->spawnflags & 8)
@@ -462,7 +462,7 @@ void SP_trigger_hurt(edict_t *self)
 {
     InitTrigger(self);
 
-    self->noise_index = gi.soundindex("world/electro.wav");
+    self->noise_index = gi_soundindex("world/electro.wav");
     self->touch = hurt_touch;
 
     if (!self->dmg)
@@ -476,7 +476,7 @@ void SP_trigger_hurt(edict_t *self)
     if (self->spawnflags & 2)
         self->use = hurt_use;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -502,7 +502,7 @@ void trigger_gravity_touch(edict_t *self, edict_t *other, cplane_t *plane, csurf
 void SP_trigger_gravity(edict_t *self)
 {
     if (st.gravity == NULL) {
-        gi.dprintf("trigger_gravity without gravity set at %s\n", vtos(self->s.origin));
+        gi_dprintf("trigger_gravity without gravity set at %s\n", vtos(self->s.origin));
         G_FreeEdict(self);
         return;
     }

--- a/src/baseq2/g_turret.c
+++ b/src/baseq2/g_turret.c
@@ -87,7 +87,7 @@ void turret_breach_fire(edict_t *self)
     damage = 100 + random() * 50;
     speed = 550 + 50 * skill->value;
     fire_rocket(self->teammaster->owner, start, f, damage, speed, 150, damage);
-    gi.positioned_sound(start, self, CHAN_WEAPON, gi.soundindex("weapons/rocklf1a.wav"), 1, ATTN_NORM, 0);
+    gi_positioned_sound(start, self, CHAN_WEAPON, gi_soundindex("weapons/rocklf1a.wav"), 1, ATTN_NORM, 0);
 }
 
 void turret_breach_think(edict_t *self)
@@ -196,7 +196,7 @@ void turret_breach_finish_init(edict_t *self)
 {
     // get and save info for muzzle location
     if (!self->target) {
-        gi.dprintf("%s at %s needs a target\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("%s at %s needs a target\n", self->classname, vtos(self->s.origin));
     } else {
         self->target_ent = G_PickTarget(self->target);
         VectorSubtract(self->target_ent->s.origin, self->s.origin, self->move_origin);
@@ -212,7 +212,7 @@ void SP_turret_breach(edict_t *self)
 {
     self->solid = SOLID_BSP;
     self->movetype = MOVETYPE_PUSH;
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
 
     if (!self->speed)
         self->speed = 50;
@@ -238,7 +238,7 @@ void SP_turret_breach(edict_t *self)
 
     self->think = turret_breach_finish_init;
     self->nextthink = level.framenum + 1;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -251,9 +251,9 @@ void SP_turret_base(edict_t *self)
 {
     self->solid = SOLID_BSP;
     self->movetype = MOVETYPE_PUSH;
-    gi.setmodel(self, self->model);
+    gi_setmodel(self, self->model);
     self->blocked = turret_blocked;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -262,7 +262,7 @@ Must NOT be on the team with the rest of the turret parts.
 Instead it must target the turret_breach.
 */
 
-void infantry_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage);
+void infantry_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point);
 void infantry_stand(edict_t *self);
 void monster_use(edict_t *self, edict_t *other, edict_t *activator);
 
@@ -283,7 +283,7 @@ void turret_driver_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int
     self->target_ent->owner = NULL;
     self->target_ent->teammaster->owner = NULL;
 
-    infantry_die(self, inflictor, attacker, damage);
+    infantry_die(self, inflictor, attacker, damage, point);
 }
 
 bool FindTarget(edict_t *self);
@@ -377,7 +377,7 @@ void SP_turret_driver(edict_t *self)
 
     self->movetype = MOVETYPE_PUSH;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/infantry/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/infantry/tris.md2");
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
 
@@ -404,11 +404,11 @@ void SP_turret_driver(edict_t *self)
     if (st.item) {
         self->item = FindItemByClassname(st.item);
         if (!self->item)
-            gi.dprintf("%s at %s has bad item: %s\n", self->classname, vtos(self->s.origin), st.item);
+            gi_dprintf("%s at %s has bad item: %s\n", self->classname, vtos(self->s.origin), st.item);
     }
 
     self->think = turret_driver_link;
     self->nextthink = level.framenum + 1;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }

--- a/src/baseq2/g_wasm.c
+++ b/src/baseq2/g_wasm.c
@@ -477,14 +477,14 @@ game_capability_t gi_QueryEngineCapability(const char *cap)
 int32_t GetGameAPI(int32_t apiversion) WASM_EXPORT(GetGameAPI)
 {
 	// bad version
-	if (apiversion != WASM_API_VERSION)
+	if (apiversion != GAME_API_EXTENDED_VERSION)
 		return 0;
 
 	pool = &entity_pool;
 	pool->edict_size = sizeof(edict_t);
 
 	// we're good!
-	return WASM_API_VERSION;
+	return GAME_API_EXTENDED_VERSION;
 }
 
 edict_t *GetEdicts(void) WASM_EXPORT(GetEdicts)

--- a/src/baseq2/g_wasm.c
+++ b/src/baseq2/g_wasm.c
@@ -246,7 +246,14 @@ void _gi_trace(float start_x, float start_y, float start_z, float mins_x, float 
 trace_t q_gameabi gi_trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, edict_t *passent, int contentmask)
 {
 	static trace_t tr;
+	
+	if (!mins)
+		mins = vec3_origin;
+	if (!maxs)
+		maxs = vec3_origin;
+
 	_gi_trace(start[0], start[1], start[2], mins[0], mins[1], mins[2], maxs[0], maxs[1], maxs[2], end[0], end[1], end[2], passent, contentmask, &tr);
+
 	return tr;
 }
 

--- a/src/baseq2/g_wasm.c
+++ b/src/baseq2/g_wasm.c
@@ -1,0 +1,520 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#if !__wasm__
+#error This file should not be compiled from a native compiler.
+#endif
+
+#include "g_local.h"
+#include "g_wasm.h"
+
+static edict_pool_t entity_pool;
+
+// Exports from elsewhere
+void InitGame(void);
+
+void WASM_Init(void) WASM_EXPORT(Init)
+{
+	InitGame();
+}
+
+void ShutdownGame(void);
+
+void WASM_Shutdown(void) WASM_EXPORT(Shutdown)
+{
+	ShutdownGame();
+}
+
+void SpawnEntities(const char *, const char *, const char *) WASM_EXPORT(SpawnEntities);
+
+void WASM_SpawnEntities(const char *mapname, const char *entstring, const char *spawnpoint) WASM_EXPORT(SpawnEntities)
+{
+	SpawnEntities(mapname, entstring, spawnpoint);
+}
+
+void WriteGame(const char *, qboolean);
+
+void WASM_WriteGame(const char *filename, qboolean autosave) WASM_EXPORT(WriteGame)
+{
+	WriteGame(filename, autosave);
+}
+
+void ReadGame(const char *);
+
+void WASM_ReadGame(const char *filename) WASM_EXPORT(ReadGame)
+{
+	ReadGame(filename);
+}
+
+void WriteLevel(const char *);
+
+void WASM_WriteLevel(const char *filename) WASM_EXPORT(WriteLevel)
+{
+	WriteLevel(filename);
+}
+
+void ReadLevel(const char *);
+
+void WASM_ReadLevel(const char *filename) WASM_EXPORT(ReadLevel)
+{
+	ReadLevel(filename);
+}
+
+void ClientThink(edict_t *, usercmd_t *);
+
+void WASM_ClientThink(edict_t *ent, usercmd_t *cmd) WASM_EXPORT(ClientThink)
+{
+	ClientThink(ent, cmd);
+}
+
+qboolean ClientConnect(edict_t *, char *);
+
+qboolean WASM_ClientConnect(edict_t *ent, char *userinfo) WASM_EXPORT(ClientConnect)
+{
+	return ClientConnect(ent, userinfo);
+}
+
+void ClientUserinfoChanged(edict_t *, char *);
+
+void WASM_ClientUserinfoChanged(edict_t *ent, char *userinfo) WASM_EXPORT(ClientUserinfoChanged)
+{
+	ClientUserinfoChanged(ent, userinfo);
+}
+
+void ClientDisconnect(edict_t *);
+
+void WASM_ClientDisconnect(edict_t *ent) WASM_EXPORT(ClientDisconnect)
+{
+	ClientDisconnect(ent);
+}
+
+void ClientBegin(edict_t *);
+
+void WASM_ClientBegin(edict_t *ent) WASM_EXPORT(ClientBegin)
+{
+	ClientBegin(ent);
+}
+
+void ClientCommand(edict_t *);
+
+void WASM_ClientCommand(edict_t *ent) WASM_EXPORT(ClientCommand)
+{
+	ClientCommand(ent);
+}
+
+void G_RunFrame(void);
+
+void WASM_RunFrame(void) WASM_EXPORT(RunFrame)
+{
+	G_RunFrame();
+}
+
+void ServerCommand(void);
+
+void WASM_ServerCommand(void) WASM_EXPORT(ServerCommand)
+{
+	ServerCommand();
+}
+
+game_capability_t QueryGameCapability(const char *);
+
+game_capability_t WASM_QueryGameCapability(const char *cap) WASM_EXPORT(QueryGameCapability)
+{
+	return QueryGameCapability(cap);
+}
+
+// Imports from native
+static char	string[1024];
+
+#define PARSE_VAR_ARGS \
+	va_list argptr; \
+	va_start (argptr, fmt); \
+	Q_vsnprintf (string, sizeof(string), fmt, argptr); \
+	va_end (argptr)
+
+void _gi_bprint(int printlevel, const char *msg) WASM_IMPORT(bprint);
+
+void q_printf(2, 3) gi_bprintf(int printlevel, const char *fmt, ...)
+{
+	PARSE_VAR_ARGS;
+	_gi_bprint(printlevel, string);
+}
+
+void _gi_dprint(const char *msg) WASM_IMPORT(dprint);
+
+void q_printf(1, 2) gi_dprintf(const char *fmt, ...)
+{
+	PARSE_VAR_ARGS;
+	_gi_dprint(string);
+}
+
+void _gi_cprint(edict_t *ent, int printlevel, const char *msg) WASM_IMPORT(cprint);
+
+void q_printf(3, 4) gi_cprintf(edict_t *ent, int printlevel, const char *fmt, ...)
+{
+	PARSE_VAR_ARGS;
+	_gi_cprint(ent, printlevel, string);
+}
+
+void _gi_centerprint(edict_t *ent, const char *msg) WASM_IMPORT(centerprint);
+
+void q_printf(2, 3) gi_centerprintf(edict_t *ent, const char *fmt, ...)
+{
+	PARSE_VAR_ARGS;
+	_gi_centerprint(ent, string);
+}
+
+void _gi_sound(edict_t *ent, int channel, int soundindex, float volume, float attenuation, float timeofs) WASM_IMPORT(sound);
+
+void gi_sound(edict_t *ent, int channel, int soundindex, float volume, float attenuation, float timeofs)
+{
+	_gi_sound(ent, channel, soundindex, volume, attenuation, timeofs);
+}
+
+void _gi_positioned_sound(float origin_x, float origin_y, float origin_z, edict_t *ent, int channel, int soundindex, float volume, float attenuation, float timeofs) WASM_IMPORT(positioned_sound);
+
+void gi_positioned_sound(vec3_t origin, edict_t *ent, int channel, int soundindex, float volume, float attenuation, float timeofs)
+{
+	if (!origin)
+		gi_sound(ent, channel, soundindex, volume, attenuation, timeofs);
+	else
+		_gi_positioned_sound(origin[0], origin[1], origin[2], ent, channel, soundindex, volume, attenuation, timeofs);
+}
+
+void _gi_configstring(int num, const char *string) WASM_IMPORT(configstring);
+
+void gi_configstring(int num, const char *string)
+{
+	_gi_configstring(num, string);
+}
+
+void q_noreturn _gi_error(const char *msg) WASM_IMPORT(error);
+
+void q_noreturn q_printf(1, 2) gi_error(const char *fmt, ...)
+{
+	PARSE_VAR_ARGS;
+	_gi_error(string);
+}
+
+int _gi_modelindex(const char *name) WASM_IMPORT(modelindex);
+
+int gi_modelindex(const char *name)
+{
+	return _gi_modelindex(name);
+}
+
+int _gi_soundindex(const char *name) WASM_IMPORT(soundindex);
+
+int gi_soundindex(const char *name)
+{
+	return _gi_soundindex(name);
+}
+
+int _gi_imageindex(const char *name) WASM_IMPORT(imageindex);
+
+int gi_imageindex(const char *name)
+{
+	return _gi_imageindex(name);
+}
+
+void _gi_setmodel(edict_t *ent, const char *name) WASM_IMPORT(setmodel);
+
+void gi_setmodel(edict_t *ent, const char *name)
+{
+	_gi_setmodel(ent, name);
+}
+
+void _gi_trace(float start_x, float start_y, float start_z, float mins_x, float mins_y, float mins_z,
+	float maxs_x, float maxs_y, float maxs_z, float end_x, float end_y, float end_z, edict_t *passent,
+	int contentmask, trace_t *out) WASM_IMPORT(trace);
+
+trace_t q_gameabi gi_trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, edict_t *passent, int contentmask)
+{
+	static trace_t tr;
+	_gi_trace(start[0], start[1], start[2], mins[0], mins[1], mins[2], maxs[0], maxs[1], maxs[2], end[0], end[1], end[2], passent, contentmask, &tr);
+	return tr;
+}
+
+int _gi_pointcontents(float point_x, float point_y, float point_z) WASM_IMPORT(pointcontents);
+
+int gi_pointcontents(vec3_t point)
+{
+	return _gi_pointcontents(point[0], point[1], point[2]);
+}
+
+qboolean _gi_inPVS(float p1_x, float p1_y, float p1_z, float p2_x, float p2_y, float p2_z) WASM_IMPORT(inPVS);
+
+qboolean gi_inPVS(vec3_t p1, vec3_t p2)
+{
+	return _gi_inPVS(p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]);
+}
+
+qboolean _gi_inPHS(float p1_x, float p1_y, float p1_z, float p2_x, float p2_y, float p2_z) WASM_IMPORT(inPHS);
+
+qboolean gi_inPHS(vec3_t p1, vec3_t p2)
+{
+	return _gi_inPHS(p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]);
+}
+
+void _gi_SetAreaPortalState(int portalnum, qboolean open) WASM_IMPORT(SetAreaPortalState);
+
+void gi_SetAreaPortalState(int portalnum, qboolean open)
+{
+	_gi_SetAreaPortalState(portalnum, open);
+}
+
+qboolean _gi_AreasConnected(int area1, int area2) WASM_IMPORT(AreasConnected);
+
+qboolean gi_AreasConnected(int area1, int area2)
+{
+	return _gi_AreasConnected(area1, area2);
+}
+
+void _gi_linkentity(edict_t *ent) WASM_IMPORT(linkentity);
+
+void gi_linkentity(edict_t *ent)
+{
+	_gi_linkentity(ent);
+}
+
+void _gi_unlinkentity(edict_t *ent) WASM_IMPORT(unlinkentity);
+
+void gi_unlinkentity(edict_t *ent)
+{
+	_gi_unlinkentity(ent);
+}
+
+int _gi_BoxEdicts(float mins_x, float mins_y, float mins_z, float maxs_x, float maxs_y, float maxs_z, edict_t **list, int maxcount, int areatype) WASM_IMPORT(BoxEdicts);
+
+int gi_BoxEdicts(vec3_t mins, vec3_t maxs, edict_t **list, int maxcount, int areatype)
+{
+	return _gi_BoxEdicts(mins[0], mins[1], mins[2], maxs[0], maxs[1], maxs[2], list, maxcount, areatype);
+}
+
+void _gi_Pmove(pmove_t *pmove) WASM_IMPORT(Pmove);
+
+void gi_Pmove(pmove_t *pmove)
+{
+	_gi_Pmove(pmove);
+}
+
+void _gi_multicast(float origin_x, float origin_y, float origin_z, multicast_t to) WASM_IMPORT(multicast);
+
+void gi_multicast(vec3_t origin, multicast_t to)
+{
+	_gi_multicast(origin[0], origin[1], origin[2], to);
+}
+
+void _gi_unicast(edict_t *ent, qboolean reliable) WASM_IMPORT(unicast);
+
+void gi_unicast(edict_t *ent, qboolean reliable)
+{
+	_gi_unicast(ent, reliable);
+}
+
+void _gi_WriteChar(int c) WASM_IMPORT(WriteChar);
+
+void gi_WriteChar(int c)
+{
+	_gi_WriteChar(c);
+}
+
+void _gi_WriteByte(int c) WASM_IMPORT(WriteByte);
+
+void gi_WriteByte(int c)
+{
+	_gi_WriteByte(c);
+}
+
+void _gi_WriteShort(int c) WASM_IMPORT(WriteShort);
+
+void gi_WriteShort(int c)
+{
+	_gi_WriteShort(c);
+}
+
+void _gi_WriteLong(int c) WASM_IMPORT(WriteLong);
+
+void gi_WriteLong(int c)
+{
+	_gi_WriteLong(c);
+}
+
+void _gi_WriteFloat(float f) WASM_IMPORT(WriteFloat);
+
+void gi_WriteFloat(float f)
+{
+	_gi_WriteFloat(f);
+}
+
+void _gi_WriteString(const char *s) WASM_IMPORT(WriteString);
+
+void gi_WriteString(const char *s)
+{
+	_gi_WriteString(s);
+}
+
+void _gi_WritePosition(float pos_x, float pos_y, float pos_z) WASM_IMPORT(WritePosition);
+
+void gi_WritePosition(const vec3_t pos)
+{
+	_gi_WritePosition(pos[0], pos[1], pos[2]);
+}
+
+void _gi_WriteDir(float pos_x, float pos_y, float pos_z) WASM_IMPORT(WriteDir);
+
+void gi_WriteDir(const vec3_t pos)
+{
+	_gi_WriteDir(pos[0], pos[1], pos[2]);
+}
+
+void _gi_WriteAngle(float f) WASM_IMPORT(WriteAngle);
+
+void gi_WriteAngle(float f)
+{
+	_gi_WriteAngle(f);
+}
+
+void *_gi_TagMalloc(unsigned size, unsigned tag) WASM_IMPORT(TagMalloc);
+
+void *gi_TagMalloc(unsigned size, unsigned tag)
+{
+	return _gi_TagMalloc(size, tag);
+}
+
+void _gi_TagFree(void *block) WASM_IMPORT(TagFree);
+
+void gi_TagFree(void *block)
+{
+	_gi_TagFree(block);
+}
+
+void _gi_FreeTags(unsigned tag) WASM_IMPORT(FreeTags);
+
+void gi_FreeTags(unsigned tag)
+{
+	_gi_FreeTags(tag);
+}
+
+cvar_t *_gi_cvar(const char *var_name, const char *value, int flags) WASM_IMPORT(cvar);
+
+cvar_t *gi_cvar(const char *var_name, const char *value, int flags)
+{
+	return _gi_cvar(var_name, value, flags);
+}
+
+cvar_t *_gi_cvar_set(const char *var_name, const char *value) WASM_IMPORT(cvar_set);
+
+cvar_t *gi_cvar_set(const char *var_name, const char *value)
+{
+	return _gi_cvar_set(var_name, value);
+}
+
+cvar_t *_gi_cvar_forceset(const char *var_name, const char *value) WASM_IMPORT(cvar_forceset);
+
+cvar_t *gi_cvar_forceset(const char *var_name, const char *value)
+{
+	return _gi_cvar_forceset(var_name, value);
+}
+
+int _gi_argc(void) WASM_IMPORT(argc);
+
+int gi_argc(void)
+{
+	return _gi_argc();
+}
+
+char *_gi_argv(int n) WASM_IMPORT(argv);
+
+char *gi_argv(int n)
+{
+	return _gi_argv(n);
+}
+
+char *_gi_args(void) WASM_IMPORT(args);
+
+char *gi_args(void)
+{
+	return _gi_args();
+}
+
+void _gi_AddCommandString(const char *text) WASM_IMPORT(AddCommandString);
+
+void gi_AddCommandString(const char *text)
+{
+	return _gi_AddCommandString(text);
+}
+
+void _gi_DebugGraph(float value, int color) WASM_IMPORT(DebugGraph);
+
+void gi_DebugGraph(float value, int color)
+{
+	return _gi_DebugGraph(value, color);
+}
+
+game_capability_t _gi_QueryEngineCapability(const char *cap) WASM_IMPORT(QueryEngineCapability);
+
+game_capability_t gi_QueryEngineCapability(const char *cap)
+{
+	return _gi_QueryEngineCapability(cap);
+}
+
+int32_t GetGameAPI(int32_t apiversion) WASM_EXPORT(GetGameAPI)
+{
+	// bad version
+	if (apiversion != WASM_API_VERSION)
+		return 0;
+
+	pool = &entity_pool;
+	pool->edict_size = sizeof(edict_t);
+
+	// we're good!
+	return WASM_API_VERSION;
+}
+
+edict_t *GetEdicts(void) WASM_EXPORT(GetEdicts)
+{
+	return entity_pool.edicts;
+}
+
+int32_t *GetNumEdicts(void) WASM_EXPORT(GetNumEdicts)
+{
+	return &entity_pool.num_edicts;
+}
+
+int32_t GetMaxEdicts(void) WASM_EXPORT(GetMaxEdicts)
+{
+	return entity_pool.max_edicts;
+}
+
+int32_t GetEdictSize(void) WASM_EXPORT(GetEdictSize)
+{
+	return entity_pool.edict_size;
+}
+
+void PmoveTrace(pmove_t *pm, float start_x, float start_y, float start_z, float mins_x, float mins_y, float mins_z,
+	float maxs_x, float maxs_y, float maxs_z, float end_x, float end_y, float end_z, trace_t *out) WASM_EXPORT(PmoveTrace)
+{
+	*out = pm->trace((float []) { start_x, start_y, start_z }, (float []) { mins_x, mins_y, mins_z },
+		(float []) { maxs_x, maxs_y, maxs_z }, (float []) { end_x, end_y, end_z });
+}
+
+int32_t PmovePointContents(pmove_t *pm, float p_x, float p_y, float p_z) WASM_EXPORT(PmovePointContents)
+{
+	return pm->pointcontents((float []) { p_x, p_y, p_z });
+}

--- a/src/baseq2/g_wasm.h
+++ b/src/baseq2/g_wasm.h
@@ -1,0 +1,29 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+// Game-local WASM stuff.
+#define WASM_EXPORT(name) \
+	__attribute__((export_name(#name)))
+
+#define WASM_IMPORT(name) \
+	__attribute__((import_module("q2"), import_name(#name)))
+
+#define DECLARE_IMPORT(r, n, ...) \
+	r wasm_ ## n(__VA_ARGS__) __WASM_IMPORT__(n)

--- a/src/baseq2/m_actor.c
+++ b/src/baseq2/m_actor.c
@@ -224,7 +224,7 @@ void actor_pain(edict_t *self, edict_t *other, float kick, int damage)
         return;
 
     self->pain_debounce_framenum = level.framenum + 3 * BASE_FRAMERATE;
-//  gi.sound (self, CHAN_VOICE, actor.sound_pain, 1, ATTN_NORM, 0);
+//  gi_sound (self, CHAN_VOICE, actor.sound_pain, 1, ATTN_NORM, 0);
 
     if ((other->client) && (random() < 0.4f)) {
         vec3_t  v;
@@ -237,7 +237,7 @@ void actor_pain(edict_t *self, edict_t *other, float kick, int damage)
         else
             self->monsterinfo.currentmove = &actor_move_taunt;
         name = actor_names[(self - g_edicts) % MAX_ACTOR_NAMES];
-        gi.cprintf(other, PRINT_CHAT, "%s: %s!\n", name, messages[Q_rand() % 3]);
+        gi_cprintf(other, PRINT_CHAT, "%s: %s!\n", name, messages[Q_rand() % 3]);
         return;
     }
 
@@ -282,7 +282,7 @@ void actor_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t actor_frames_death1 [] = {
@@ -319,7 +319,7 @@ void actor_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
 
 // check for gib
     if (self->health <= -80) {
-//      gi.sound (self, CHAN_VOICE, actor.sound_gib, 1, ATTN_NORM, 0);
+//      gi_sound (self, CHAN_VOICE, actor.sound_gib, 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -333,7 +333,7 @@ void actor_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
         return;
 
 // regular death
-//  gi.sound (self, CHAN_VOICE, actor.sound_die, 1, ATTN_NORM, 0);
+//  gi_sound (self, CHAN_VOICE, actor.sound_die, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
 
@@ -379,7 +379,7 @@ void actor_use(edict_t *self, edict_t *other, edict_t *activator)
 
     self->goalentity = self->movetarget = G_PickTarget(self->target);
     if ((!self->movetarget) || (strcmp(self->movetarget->classname, "target_actor") != 0)) {
-        gi.dprintf("%s has bad target %s at %s\n", self->classname, self->target, vtos(self->s.origin));
+        gi_dprintf("%s has bad target %s at %s\n", self->classname, self->target, vtos(self->s.origin));
         self->target = NULL;
         self->monsterinfo.pause_framenum = INT_MAX;
         self->monsterinfo.stand(self);
@@ -404,20 +404,20 @@ void SP_misc_actor(edict_t *self)
     }
 
     if (!self->targetname) {
-        gi.dprintf("untargeted %s at %s\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("untargeted %s at %s\n", self->classname, vtos(self->s.origin));
         G_FreeEdict(self);
         return;
     }
 
     if (!self->target) {
-        gi.dprintf("%s with no target at %s\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("%s with no target at %s\n", self->classname, vtos(self->s.origin));
         G_FreeEdict(self);
         return;
     }
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("players/male/tris.md2");
+    self->s.modelindex = gi_modelindex("players/male/tris.md2");
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
 
@@ -437,7 +437,7 @@ void SP_misc_actor(edict_t *self)
 
     self->monsterinfo.aiflags |= AI_GOOD_GUY;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &actor_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;
@@ -484,7 +484,7 @@ void target_actor_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface
             ent = &g_edicts[n];
             if (!ent->inuse)
                 continue;
-            gi.cprintf(ent, PRINT_CHAT, "%s: %s\n", actor_names[(other - g_edicts) % MAX_ACTOR_NAMES], self->message);
+            gi_cprintf(ent, PRINT_CHAT, "%s: %s\n", actor_names[(other - g_edicts) % MAX_ACTOR_NAMES], self->message);
         }
     }
 
@@ -495,7 +495,7 @@ void target_actor_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface
         if (other->groundentity) {
             other->groundentity = NULL;
             other->velocity[2] = self->movedir[2];
-            gi.sound(other, CHAN_VOICE, gi.soundindex("player/male/jump1.wav"), 1, ATTN_NORM, 0);
+            gi_sound(other, CHAN_VOICE, gi_soundindex("player/male/jump1.wav"), 1, ATTN_NORM, 0);
         }
     }
 
@@ -541,7 +541,7 @@ void target_actor_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface
 void SP_target_actor(edict_t *self)
 {
     if (!self->targetname)
-        gi.dprintf("%s with no targetname at %s\n", self->classname, vtos(self->s.origin));
+        gi_dprintf("%s with no targetname at %s\n", self->classname, vtos(self->s.origin));
 
     self->solid = SOLID_TRIGGER;
     self->touch = target_actor_touch;
@@ -560,5 +560,5 @@ void SP_target_actor(edict_t *self)
         self->movedir[2] = st.height;
     }
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }

--- a/src/baseq2/m_berserk.c
+++ b/src/baseq2/m_berserk.c
@@ -36,12 +36,12 @@ static int sound_search;
 
 void berserk_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void berserk_search(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
 }
 
 
@@ -92,7 +92,7 @@ void berserk_fidget(edict_t *self)
         return;
 
     self->monsterinfo.currentmove = &berserk_move_stand_fidget;
-    gi.sound(self, CHAN_WEAPON, sound_idle, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_WEAPON, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 
@@ -170,7 +170,7 @@ void berserk_attack_spike(edict_t *self)
 
 void berserk_swing(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_punch, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_punch, 1, ATTN_NORM, 0);
 }
 
 mframe_t berserk_frames_attack_spike [] = {
@@ -310,7 +310,7 @@ void berserk_pain(edict_t *self, edict_t *other, float kick, int damage)
         return;
 
     self->pain_debounce_framenum = level.framenum + 3 * BASE_FRAMERATE;
-    gi.sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
 
     if (skill->value == 3)
         return;     // no pain anims in nightmare
@@ -329,7 +329,7 @@ void berserk_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -370,7 +370,7 @@ void berserk_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
     int     n;
 
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -383,7 +383,7 @@ void berserk_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
     if (self->deadflag == DEAD_DEAD)
         return;
 
-    gi.sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
 
@@ -404,14 +404,14 @@ void SP_monster_berserk(edict_t *self)
     }
 
     // pre-caches
-    sound_pain  = gi.soundindex("berserk/berpain2.wav");
-    sound_die   = gi.soundindex("berserk/berdeth2.wav");
-    sound_idle  = gi.soundindex("berserk/beridle1.wav");
-    sound_punch = gi.soundindex("berserk/attack.wav");
-    sound_search = gi.soundindex("berserk/bersrch1.wav");
-    sound_sight = gi.soundindex("berserk/sight.wav");
+    sound_pain  = gi_soundindex("berserk/berpain2.wav");
+    sound_die   = gi_soundindex("berserk/berdeth2.wav");
+    sound_idle  = gi_soundindex("berserk/beridle1.wav");
+    sound_punch = gi_soundindex("berserk/attack.wav");
+    sound_search = gi_soundindex("berserk/bersrch1.wav");
+    sound_sight = gi_soundindex("berserk/sight.wav");
 
-    self->s.modelindex = gi.modelindex("models/monsters/berserk/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/berserk/tris.md2");
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
     self->movetype = MOVETYPE_STEP;
@@ -436,7 +436,7 @@ void SP_monster_berserk(edict_t *self)
     self->monsterinfo.currentmove = &berserk_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     walkmonster_start(self);
 }

--- a/src/baseq2/m_boss2.c
+++ b/src/baseq2/m_boss2.c
@@ -39,7 +39,7 @@ static int  sound_search1;
 void boss2_search(edict_t *self)
 {
     if (random() < 0.5f)
-        gi.sound(self, CHAN_VOICE, sound_search1, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_VOICE, sound_search1, 1, ATTN_NONE, 0);
 }
 
 void boss2_run(edict_t *self);
@@ -462,13 +462,13 @@ void boss2_pain(edict_t *self, edict_t *other, float kick, int damage)
     self->pain_debounce_framenum = level.framenum + 3 * BASE_FRAMERATE;
 // American wanted these at no attenuation
     if (damage < 10) {
-        gi.sound(self, CHAN_VOICE, sound_pain3, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain3, 1, ATTN_NONE, 0);
         self->monsterinfo.currentmove = &boss2_move_pain_light;
     } else if (damage < 30) {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NONE, 0);
         self->monsterinfo.currentmove = &boss2_move_pain_light;
     } else {
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NONE, 0);
         self->monsterinfo.currentmove = &boss2_move_pain_heavy;
     }
 }
@@ -480,12 +480,12 @@ void boss2_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void boss2_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
-    gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NONE, 0);
+    gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NONE, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_NO;
     self->count = 0;
@@ -496,7 +496,7 @@ void boss2_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
     self->s.sound = 0;
     // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -531,7 +531,7 @@ bool Boss2_CheckAttack(edict_t *self)
         VectorCopy(self->enemy->s.origin, spot2);
         spot2[2] += self->enemy->viewheight;
 
-        tr = gi.trace(spot1, NULL, NULL, spot2, self, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_SLIME | CONTENTS_LAVA);
+        tr = gi_trace(spot1, NULL, NULL, spot2, self, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_SLIME | CONTENTS_LAVA);
 
         // do we have a clear shot?
         if (tr.ent != self->enemy)
@@ -603,17 +603,17 @@ void SP_monster_boss2(edict_t *self)
         return;
     }
 
-    sound_pain1 = gi.soundindex("bosshovr/bhvpain1.wav");
-    sound_pain2 = gi.soundindex("bosshovr/bhvpain2.wav");
-    sound_pain3 = gi.soundindex("bosshovr/bhvpain3.wav");
-    sound_death = gi.soundindex("bosshovr/bhvdeth1.wav");
-    sound_search1 = gi.soundindex("bosshovr/bhvunqv1.wav");
+    sound_pain1 = gi_soundindex("bosshovr/bhvpain1.wav");
+    sound_pain2 = gi_soundindex("bosshovr/bhvpain2.wav");
+    sound_pain3 = gi_soundindex("bosshovr/bhvpain3.wav");
+    sound_death = gi_soundindex("bosshovr/bhvdeth1.wav");
+    sound_search1 = gi_soundindex("bosshovr/bhvunqv1.wav");
 
-    self->s.sound = gi.soundindex("bosshovr/bhvengn1.wav");
+    self->s.sound = gi_soundindex("bosshovr/bhvengn1.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/boss2/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/boss2/tris.md2");
     VectorSet(self->mins, -56, -56, 0);
     VectorSet(self->maxs, 56, 56, 80);
 
@@ -632,7 +632,7 @@ void SP_monster_boss2(edict_t *self)
     self->monsterinfo.attack = boss2_attack;
     self->monsterinfo.search = boss2_search;
     self->monsterinfo.checkattack = Boss2_CheckAttack;
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &boss2_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_boss3.c
+++ b/src/baseq2/m_boss3.c
@@ -28,10 +28,10 @@ boss3
 
 void Use_Boss3(edict_t *ent, edict_t *other, edict_t *activator)
 {
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_BOSSTPORT);
-    gi.WritePosition(ent->s.origin);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_BOSSTPORT);
+    gi_WritePosition(ent->s.origin);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
     G_FreeEdict(ent);
 }
 
@@ -58,10 +58,10 @@ void SP_monster_boss3_stand(edict_t *self)
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
     self->model = "models/monsters/boss3/rider/tris.md2";
-    self->s.modelindex = gi.modelindex(self->model);
+    self->s.modelindex = gi_modelindex(self->model);
     self->s.frame = FRAME_stand201;
 
-    gi.soundindex("misc/bigtele.wav");
+    gi_soundindex("misc/bigtele.wav");
 
     VectorSet(self->mins, -32, -32, 0);
     VectorSet(self->maxs, 32, 32, 90);
@@ -69,5 +69,5 @@ void SP_monster_boss3_stand(edict_t *self)
     self->use = Use_Boss3;
     self->think = Think_Boss3Stand;
     self->nextthink = level.framenum + 1;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }

--- a/src/baseq2/m_boss31.c
+++ b/src/baseq2/m_boss31.c
@@ -55,11 +55,11 @@ void jorg_search(edict_t *self)
     r = random();
 
     if (r <= 0.3f)
-        gi.sound(self, CHAN_VOICE, sound_search1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_search1, 1, ATTN_NORM, 0);
     else if (r <= 0.6f)
-        gi.sound(self, CHAN_VOICE, sound_search2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_search2, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_search3, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_search3, 1, ATTN_NORM, 0);
 }
 
 
@@ -135,23 +135,23 @@ mmove_t jorg_move_stand = {FRAME_stand01, FRAME_stand51, jorg_frames_stand, NULL
 
 void jorg_idle(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_NORM, 0);
 }
 
 void jorg_death_hit(edict_t *self)
 {
-    gi.sound(self, CHAN_BODY, sound_death_hit, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_death_hit, 1, ATTN_NORM, 0);
 }
 
 
 void jorg_step_left(edict_t *self)
 {
-    gi.sound(self, CHAN_BODY, sound_step_left, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_step_left, 1, ATTN_NORM, 0);
 }
 
 void jorg_step_right(edict_t *self)
 {
-    gi.sound(self, CHAN_BODY, sound_step_right, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_step_right, 1, ATTN_NORM, 0);
 }
 
 
@@ -436,14 +436,14 @@ void jorg_pain(edict_t *self, edict_t *other, float kick, int damage)
         return;     // no pain anims in nightmare
 
     if (damage <= 50) {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &jorg_move_pain1;
     } else if (damage <= 100) {
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &jorg_move_pain2;
     } else {
         if (random() <= 0.3f) {
-            gi.sound(self, CHAN_VOICE, sound_pain3, 1, ATTN_NORM, 0);
+            gi_sound(self, CHAN_VOICE, sound_pain3, 1, ATTN_NORM, 0);
             self->monsterinfo.currentmove = &jorg_move_pain3;
         }
     }
@@ -463,7 +463,7 @@ void jorgBFG(edict_t *self)
     vec[2] += self->enemy->viewheight;
     VectorSubtract(vec, start, dir);
     VectorNormalize(dir);
-    gi.sound(self, CHAN_VOICE, sound_attack2, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_attack2, 1, ATTN_NORM, 0);
     /*void monster_fire_bfg (edict_t *self,
                              vec3_t start,
                              vec3_t aimdir,
@@ -516,11 +516,11 @@ void jorg_firebullet(edict_t *self)
 void jorg_attack(edict_t *self)
 {
     if (random() <= 0.75f) {
-        gi.sound(self, CHAN_VOICE, sound_attack1, 1, ATTN_NORM, 0);
-        self->s.sound = gi.soundindex("boss3/w_loop.wav");
+        gi_sound(self, CHAN_VOICE, sound_attack1, 1, ATTN_NORM, 0);
+        self->s.sound = gi_soundindex("boss3/w_loop.wav");
         self->monsterinfo.currentmove = &jorg_move_start_attack1;
     } else {
-        gi.sound(self, CHAN_VOICE, sound_attack2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_attack2, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &jorg_move_attack2;
     }
 }
@@ -539,7 +539,7 @@ void jorg_dead(edict_t *self)
     VectorSet(self->maxs, 60, 60, 72);
     self->movetype = MOVETYPE_TOSS;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     tempent = G_Spawn();
     VectorCopy(self->s.origin, tempent->s.origin);
@@ -556,7 +556,7 @@ void jorg_dead(edict_t *self)
 
 void jorg_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
-    gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_NO;
     self->s.sound = 0;
@@ -580,7 +580,7 @@ bool Jorg_CheckAttack(edict_t *self)
         VectorCopy(self->enemy->s.origin, spot2);
         spot2[2] += self->enemy->viewheight;
 
-        tr = gi.trace(spot1, NULL, NULL, spot2, self, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_SLIME | CONTENTS_LAVA);
+        tr = gi_trace(spot1, NULL, NULL, spot2, self, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_SLIME | CONTENTS_LAVA);
 
         // do we have a clear shot?
         if (tr.ent != self->enemy)
@@ -653,27 +653,27 @@ void SP_monster_jorg(edict_t *self)
         return;
     }
 
-    sound_pain1 = gi.soundindex("boss3/bs3pain1.wav");
-    sound_pain2 = gi.soundindex("boss3/bs3pain2.wav");
-    sound_pain3 = gi.soundindex("boss3/bs3pain3.wav");
-    sound_death = gi.soundindex("boss3/bs3deth1.wav");
-    sound_attack1 = gi.soundindex("boss3/bs3atck1.wav");
-    sound_attack2 = gi.soundindex("boss3/bs3atck2.wav");
-    sound_search1 = gi.soundindex("boss3/bs3srch1.wav");
-    sound_search2 = gi.soundindex("boss3/bs3srch2.wav");
-    sound_search3 = gi.soundindex("boss3/bs3srch3.wav");
-    sound_idle = gi.soundindex("boss3/bs3idle1.wav");
-    sound_step_left = gi.soundindex("boss3/step1.wav");
-    sound_step_right = gi.soundindex("boss3/step2.wav");
-    sound_firegun = gi.soundindex("boss3/xfire.wav");
-    sound_death_hit = gi.soundindex("boss3/d_hit.wav");
+    sound_pain1 = gi_soundindex("boss3/bs3pain1.wav");
+    sound_pain2 = gi_soundindex("boss3/bs3pain2.wav");
+    sound_pain3 = gi_soundindex("boss3/bs3pain3.wav");
+    sound_death = gi_soundindex("boss3/bs3deth1.wav");
+    sound_attack1 = gi_soundindex("boss3/bs3atck1.wav");
+    sound_attack2 = gi_soundindex("boss3/bs3atck2.wav");
+    sound_search1 = gi_soundindex("boss3/bs3srch1.wav");
+    sound_search2 = gi_soundindex("boss3/bs3srch2.wav");
+    sound_search3 = gi_soundindex("boss3/bs3srch3.wav");
+    sound_idle = gi_soundindex("boss3/bs3idle1.wav");
+    sound_step_left = gi_soundindex("boss3/step1.wav");
+    sound_step_right = gi_soundindex("boss3/step2.wav");
+    sound_firegun = gi_soundindex("boss3/xfire.wav");
+    sound_death_hit = gi_soundindex("boss3/d_hit.wav");
 
     MakronPrecache();
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/boss3/rider/tris.md2");
-    self->s.modelindex2 = gi.modelindex("models/monsters/boss3/jorg/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/boss3/rider/tris.md2");
+    self->s.modelindex2 = gi_modelindex("models/monsters/boss3/jorg/tris.md2");
     VectorSet(self->mins, -80, -80, 0);
     VectorSet(self->maxs, 80, 80, 140);
 
@@ -692,7 +692,7 @@ void SP_monster_jorg(edict_t *self)
     self->monsterinfo.melee = NULL;
     self->monsterinfo.sight = NULL;
     self->monsterinfo.checkattack = Jorg_CheckAttack;
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &jorg_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_boss32.c
+++ b/src/baseq2/m_boss32.c
@@ -57,11 +57,11 @@ void makron_taunt(edict_t *self)
 
     r = random();
     if (r <= 0.3f)
-        gi.sound(self, CHAN_AUTO, sound_taunt1, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_AUTO, sound_taunt1, 1, ATTN_NONE, 0);
     else if (r <= 0.6f)
-        gi.sound(self, CHAN_AUTO, sound_taunt2, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_AUTO, sound_taunt2, 1, ATTN_NONE, 0);
     else
-        gi.sound(self, CHAN_AUTO, sound_taunt3, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_AUTO, sound_taunt3, 1, ATTN_NONE, 0);
 }
 
 //
@@ -153,32 +153,32 @@ mmove_t makron_move_run = {FRAME_walk204, FRAME_walk213, makron_frames_run, NULL
 
 void makron_hit(edict_t *self)
 {
-    gi.sound(self, CHAN_AUTO, sound_hit, 1, ATTN_NONE, 0);
+    gi_sound(self, CHAN_AUTO, sound_hit, 1, ATTN_NONE, 0);
 }
 
 void makron_popup(edict_t *self)
 {
-    gi.sound(self, CHAN_BODY, sound_popup, 1, ATTN_NONE, 0);
+    gi_sound(self, CHAN_BODY, sound_popup, 1, ATTN_NONE, 0);
 }
 
 void makron_step_left(edict_t *self)
 {
-    gi.sound(self, CHAN_BODY, sound_step_left, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_step_left, 1, ATTN_NORM, 0);
 }
 
 void makron_step_right(edict_t *self)
 {
-    gi.sound(self, CHAN_BODY, sound_step_right, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_step_right, 1, ATTN_NORM, 0);
 }
 
 void makron_brainsplorch(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_brainsplorch, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_brainsplorch, 1, ATTN_NORM, 0);
 }
 
 void makron_prerailgun(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_prerailgun, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_prerailgun, 1, ATTN_NORM, 0);
 }
 
 
@@ -410,7 +410,7 @@ void makronBFG(edict_t *self)
     vec[2] += self->enemy->viewheight;
     VectorSubtract(vec, start, dir);
     VectorNormalize(dir);
-    gi.sound(self, CHAN_VOICE, sound_attack_bfg, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_attack_bfg, 1, ATTN_NORM, 0);
     monster_fire_bfg(self, start, dir, 50, 300, 100, 300, MZ2_MAKRON_BFG);
 }
 
@@ -555,20 +555,20 @@ void makron_pain(edict_t *self, edict_t *other, float kick, int damage)
 
 
     if (damage <= 40) {
-        gi.sound(self, CHAN_VOICE, sound_pain4, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain4, 1, ATTN_NONE, 0);
         self->monsterinfo.currentmove = &makron_move_pain4;
     } else if (damage <= 110) {
-        gi.sound(self, CHAN_VOICE, sound_pain5, 1, ATTN_NONE, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain5, 1, ATTN_NONE, 0);
         self->monsterinfo.currentmove = &makron_move_pain5;
     } else {
         if (damage <= 150) {
             if (random() <= 0.45f) {
-                gi.sound(self, CHAN_VOICE, sound_pain6, 1, ATTN_NONE, 0);
+                gi_sound(self, CHAN_VOICE, sound_pain6, 1, ATTN_NONE, 0);
                 self->monsterinfo.currentmove = &makron_move_pain6;
             }
         } else {
             if (random() <= 0.35f) {
-                gi.sound(self, CHAN_VOICE, sound_pain6, 1, ATTN_NONE, 0);
+                gi_sound(self, CHAN_VOICE, sound_pain6, 1, ATTN_NONE, 0);
                 self->monsterinfo.currentmove = &makron_move_pain6;
             }
         }
@@ -617,11 +617,11 @@ void makron_torso(edict_t *ent)
     VectorSet(ent->mins, -8, -8, 0);
     VectorSet(ent->maxs, 8, 8, 8);
     ent->s.frame = 346;
-    ent->s.modelindex = gi.modelindex("models/monsters/boss3/rider/tris.md2");
+    ent->s.modelindex = gi_modelindex("models/monsters/boss3/rider/tris.md2");
     ent->think = makron_torso_think;
     ent->nextthink = level.framenum + 2;
-    ent->s.sound = gi.soundindex("makron/spine.wav");
-    gi.linkentity(ent);
+    ent->s.sound = gi_soundindex("makron/spine.wav");
+    gi_linkentity(ent);
 }
 
 
@@ -636,7 +636,7 @@ void makron_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -649,7 +649,7 @@ void makron_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
     self->s.sound = 0;
     // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 1 /*4*/; n++)
             ThrowGib(self, "models/objects/gibs/sm_meat/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -663,7 +663,7 @@ void makron_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
         return;
 
 // regular death
-    gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NONE, 0);
+    gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NONE, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
 
@@ -693,7 +693,7 @@ bool Makron_CheckAttack(edict_t *self)
         VectorCopy(self->enemy->s.origin, spot2);
         spot2[2] += self->enemy->viewheight;
 
-        tr = gi.trace(spot1, NULL, NULL, spot2, self, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_SLIME | CONTENTS_LAVA);
+        tr = gi_trace(spot1, NULL, NULL, spot2, self, CONTENTS_SOLID | CONTENTS_MONSTER | CONTENTS_SLIME | CONTENTS_LAVA);
 
         // do we have a clear shot?
         if (tr.ent != self->enemy)
@@ -761,22 +761,22 @@ bool Makron_CheckAttack(edict_t *self)
 
 void MakronPrecache(void)
 {
-    sound_pain4 = gi.soundindex("makron/pain3.wav");
-    sound_pain5 = gi.soundindex("makron/pain2.wav");
-    sound_pain6 = gi.soundindex("makron/pain1.wav");
-    sound_death = gi.soundindex("makron/death.wav");
-    sound_step_left = gi.soundindex("makron/step1.wav");
-    sound_step_right = gi.soundindex("makron/step2.wav");
-    sound_attack_bfg = gi.soundindex("makron/bfg_fire.wav");
-    sound_brainsplorch = gi.soundindex("makron/brain1.wav");
-    sound_prerailgun = gi.soundindex("makron/rail_up.wav");
-    sound_popup = gi.soundindex("makron/popup.wav");
-    sound_taunt1 = gi.soundindex("makron/voice4.wav");
-    sound_taunt2 = gi.soundindex("makron/voice3.wav");
-    sound_taunt3 = gi.soundindex("makron/voice.wav");
-    sound_hit = gi.soundindex("makron/bhit.wav");
+    sound_pain4 = gi_soundindex("makron/pain3.wav");
+    sound_pain5 = gi_soundindex("makron/pain2.wav");
+    sound_pain6 = gi_soundindex("makron/pain1.wav");
+    sound_death = gi_soundindex("makron/death.wav");
+    sound_step_left = gi_soundindex("makron/step1.wav");
+    sound_step_right = gi_soundindex("makron/step2.wav");
+    sound_attack_bfg = gi_soundindex("makron/bfg_fire.wav");
+    sound_brainsplorch = gi_soundindex("makron/brain1.wav");
+    sound_prerailgun = gi_soundindex("makron/rail_up.wav");
+    sound_popup = gi_soundindex("makron/popup.wav");
+    sound_taunt1 = gi_soundindex("makron/voice4.wav");
+    sound_taunt2 = gi_soundindex("makron/voice3.wav");
+    sound_taunt3 = gi_soundindex("makron/voice.wav");
+    sound_hit = gi_soundindex("makron/bhit.wav");
 
-    gi.modelindex("models/monsters/boss3/rider/tris.md2");
+    gi_modelindex("models/monsters/boss3/rider/tris.md2");
 }
 
 /*QUAKED monster_makron (1 .5 0) (-30 -30 0) (30 30 90) Ambush Trigger_Spawn Sight
@@ -792,7 +792,7 @@ void SP_monster_makron(edict_t *self)
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/boss3/rider/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/boss3/rider/tris.md2");
     VectorSet(self->mins, -30, -30, 0);
     VectorSet(self->maxs, 30, 30, 90);
 
@@ -811,7 +811,7 @@ void SP_monster_makron(edict_t *self)
     self->monsterinfo.sight = makron_sight;
     self->monsterinfo.checkattack = Makron_CheckAttack;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
 //  self->monsterinfo.currentmove = &makron_move_stand;
     self->monsterinfo.currentmove = &makron_move_sight;

--- a/src/baseq2/m_brain.c
+++ b/src/baseq2/m_brain.c
@@ -45,12 +45,12 @@ static int  sound_melee3;
 
 void brain_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void brain_search(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
 }
 
 
@@ -146,7 +146,7 @@ mmove_t brain_move_idle = {FRAME_stand31, FRAME_stand60, brain_frames_idle, brai
 
 void brain_idle(edict_t *self)
 {
-    gi.sound(self, CHAN_AUTO, sound_idle3, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_AUTO, sound_idle3, 1, ATTN_IDLE, 0);
     self->monsterinfo.currentmove = &brain_move_idle;
 }
 
@@ -312,7 +312,7 @@ void brain_duck_down(edict_t *self) {
     self->monsterinfo.aiflags |= AI_DUCKED;
     self->maxs[2] -= 32;
     self->takedamage = DAMAGE_YES;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void brain_duck_hold(edict_t *self) {
@@ -326,7 +326,7 @@ void brain_duck_up(edict_t *self) {
     self->monsterinfo.aiflags &= ~AI_DUCKED;
     self->maxs[2] += 32;
     self->takedamage = DAMAGE_AIM;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t brain_frames_duck [] =
@@ -393,7 +393,7 @@ mmove_t brain_move_death1 = {FRAME_death101, FRAME_death118, brain_frames_death1
 //
 
 void brain_swing_right(edict_t *self) {
-    gi.sound(self, CHAN_BODY, sound_melee1, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_melee1, 1, ATTN_NORM, 0);
 }
 
 void brain_hit_right(edict_t *self) {
@@ -401,11 +401,11 @@ void brain_hit_right(edict_t *self) {
 
     VectorSet(aim, MELEE_DISTANCE, self->maxs[0], 8);
     if (fire_hit(self, aim, (15 + (Q_rand() % 5)), 40))
-        gi.sound(self, CHAN_WEAPON, sound_melee3, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_melee3, 1, ATTN_NORM, 0);
 }
 
 void brain_swing_left(edict_t *self) {
-    gi.sound(self, CHAN_BODY, sound_melee2, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_melee2, 1, ATTN_NORM, 0);
 }
 
 void brain_hit_left(edict_t *self) {
@@ -413,7 +413,7 @@ void brain_hit_left(edict_t *self) {
 
     VectorSet(aim, MELEE_DISTANCE, self->mins[0], 8);
     if (fire_hit(self, aim, (15 + (Q_rand() % 5)), 40))
-        gi.sound(self, CHAN_WEAPON, sound_melee3, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_melee3, 1, ATTN_NORM, 0);
 }
 
 mframe_t brain_frames_attack1 [] =
@@ -442,7 +442,7 @@ mmove_t brain_move_attack1 = {FRAME_attak101, FRAME_attak118, brain_frames_attac
 void brain_chest_open(edict_t *self) {
     self->spawnflags &= ~65536;
     self->monsterinfo.power_armor_type = POWER_ARMOR_NONE;
-    gi.sound(self, CHAN_BODY, sound_chest_open, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_chest_open, 1, ATTN_NORM, 0);
 }
 
 void brain_tentacle_attack(edict_t *self) {
@@ -451,7 +451,7 @@ void brain_tentacle_attack(edict_t *self) {
     VectorSet(aim, MELEE_DISTANCE, 0, 8);
     if (fire_hit(self, aim, (10 + (Q_rand() % 5)), -600) && skill->value > 0)
         self->spawnflags |= 65536;
-    gi.sound(self, CHAN_WEAPON, sound_tentacles_retract, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_tentacles_retract, 1, ATTN_NORM, 0);
 }
 
 void brain_chest_closed(edict_t *self) {
@@ -536,13 +536,13 @@ void brain_pain(edict_t *self, edict_t *other, float kick, int damage) {
 
     r = random();
     if (r < 0.33f) {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &brain_move_pain1;
     } else if (r < 0.66f) {
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &brain_move_pain2;
     } else {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &brain_move_pain3;
     }
 }
@@ -553,7 +553,7 @@ void brain_dead(edict_t *self) {
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -566,7 +566,7 @@ void brain_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -580,7 +580,7 @@ void brain_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
         return;
 
 // regular death
-    gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
     if (random() <= 0.5f)
@@ -597,24 +597,24 @@ void SP_monster_brain(edict_t *self) {
         return;
     }
 
-    sound_chest_open = gi.soundindex("brain/brnatck1.wav");
-    sound_tentacles_extend = gi.soundindex("brain/brnatck2.wav");
-    sound_tentacles_retract = gi.soundindex("brain/brnatck3.wav");
-    sound_death = gi.soundindex("brain/brndeth1.wav");
-    sound_idle1 = gi.soundindex("brain/brnidle1.wav");
-    sound_idle2 = gi.soundindex("brain/brnidle2.wav");
-    sound_idle3 = gi.soundindex("brain/brnlens1.wav");
-    sound_pain1 = gi.soundindex("brain/brnpain1.wav");
-    sound_pain2 = gi.soundindex("brain/brnpain2.wav");
-    sound_sight = gi.soundindex("brain/brnsght1.wav");
-    sound_search = gi.soundindex("brain/brnsrch1.wav");
-    sound_melee1 = gi.soundindex("brain/melee1.wav");
-    sound_melee2 = gi.soundindex("brain/melee2.wav");
-    sound_melee3 = gi.soundindex("brain/melee3.wav");
+    sound_chest_open = gi_soundindex("brain/brnatck1.wav");
+    sound_tentacles_extend = gi_soundindex("brain/brnatck2.wav");
+    sound_tentacles_retract = gi_soundindex("brain/brnatck3.wav");
+    sound_death = gi_soundindex("brain/brndeth1.wav");
+    sound_idle1 = gi_soundindex("brain/brnidle1.wav");
+    sound_idle2 = gi_soundindex("brain/brnidle2.wav");
+    sound_idle3 = gi_soundindex("brain/brnlens1.wav");
+    sound_pain1 = gi_soundindex("brain/brnpain1.wav");
+    sound_pain2 = gi_soundindex("brain/brnpain2.wav");
+    sound_sight = gi_soundindex("brain/brnsght1.wav");
+    sound_search = gi_soundindex("brain/brnsrch1.wav");
+    sound_melee1 = gi_soundindex("brain/melee1.wav");
+    sound_melee2 = gi_soundindex("brain/melee2.wav");
+    sound_melee3 = gi_soundindex("brain/melee3.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/brain/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/brain/tris.md2");
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
 
@@ -638,7 +638,7 @@ void SP_monster_brain(edict_t *self) {
     self->monsterinfo.power_armor_type = POWER_ARMOR_SCREEN;
     self->monsterinfo.power_armor_power = 100;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &brain_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_chick.c
+++ b/src/baseq2/m_chick.c
@@ -54,9 +54,9 @@ static int  sound_search;
 void ChickMoan(edict_t *self)
 {
     if (random() < 0.5f)
-        gi.sound(self, CHAN_VOICE, sound_idle1, 1, ATTN_IDLE, 0);
+        gi_sound(self, CHAN_VOICE, sound_idle1, 1, ATTN_IDLE, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_idle2, 1, ATTN_IDLE, 0);
+        gi_sound(self, CHAN_VOICE, sound_idle2, 1, ATTN_IDLE, 0);
 }
 
 mframe_t chick_frames_fidget [] = {
@@ -263,11 +263,11 @@ void chick_pain(edict_t *self, edict_t *other, float kick, int damage)
 
     r = random();
     if (r < 0.33f)
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
     else if (r < 0.66f)
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_pain3, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain3, 1, ATTN_NORM, 0);
 
     if (skill->value == 3)
         return;     // no pain anims in nightmare
@@ -287,7 +287,7 @@ void chick_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t chick_frames_death2 [] = {
@@ -340,7 +340,7 @@ void chick_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -360,10 +360,10 @@ void chick_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
     n = Q_rand() % 2;
     if (n == 0) {
         self->monsterinfo.currentmove = &chick_move_death1;
-        gi.sound(self, CHAN_VOICE, sound_death1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_death1, 1, ATTN_NORM, 0);
     } else {
         self->monsterinfo.currentmove = &chick_move_death2;
-        gi.sound(self, CHAN_VOICE, sound_death2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_death2, 1, ATTN_NORM, 0);
     }
 }
 
@@ -376,7 +376,7 @@ void chick_duck_down(edict_t *self)
     self->maxs[2] -= 32;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.pause_framenum = level.framenum + 1 * BASE_FRAMERATE;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void chick_duck_hold(edict_t *self)
@@ -392,7 +392,7 @@ void chick_duck_up(edict_t *self)
     self->monsterinfo.aiflags &= ~AI_DUCKED;
     self->maxs[2] += 32;
     self->takedamage = DAMAGE_AIM;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t chick_frames_duck [] = {
@@ -422,7 +422,7 @@ void ChickSlash(edict_t *self)
     vec3_t  aim;
 
     VectorSet(aim, MELEE_DISTANCE, self->mins[0], 10);
-    gi.sound(self, CHAN_WEAPON, sound_melee_swing, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_melee_swing, 1, ATTN_NORM, 0);
     fire_hit(self, aim, (10 + (Q_rand() % 6)), 100);
 }
 
@@ -447,12 +447,12 @@ void ChickRocket(edict_t *self)
 
 void Chick_PreAttack1(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_missile_prelaunch, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_missile_prelaunch, 1, ATTN_NORM, 0);
 }
 
 void ChickReload(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_missile_reload, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_missile_reload, 1, ATTN_NORM, 0);
 }
 
 
@@ -586,7 +586,7 @@ void chick_attack(edict_t *self)
 
 void chick_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 /*QUAKED monster_chick (1 .5 0) (-16 -16 -24) (16 16 32) Ambush Trigger_Spawn Sight
@@ -598,25 +598,25 @@ void SP_monster_chick(edict_t *self)
         return;
     }
 
-    sound_missile_prelaunch = gi.soundindex("chick/chkatck1.wav");
-    sound_missile_launch    = gi.soundindex("chick/chkatck2.wav");
-    sound_melee_swing       = gi.soundindex("chick/chkatck3.wav");
-    sound_melee_hit         = gi.soundindex("chick/chkatck4.wav");
-    sound_missile_reload    = gi.soundindex("chick/chkatck5.wav");
-    sound_death1            = gi.soundindex("chick/chkdeth1.wav");
-    sound_death2            = gi.soundindex("chick/chkdeth2.wav");
-    sound_fall_down         = gi.soundindex("chick/chkfall1.wav");
-    sound_idle1             = gi.soundindex("chick/chkidle1.wav");
-    sound_idle2             = gi.soundindex("chick/chkidle2.wav");
-    sound_pain1             = gi.soundindex("chick/chkpain1.wav");
-    sound_pain2             = gi.soundindex("chick/chkpain2.wav");
-    sound_pain3             = gi.soundindex("chick/chkpain3.wav");
-    sound_sight             = gi.soundindex("chick/chksght1.wav");
-    sound_search            = gi.soundindex("chick/chksrch1.wav");
+    sound_missile_prelaunch = gi_soundindex("chick/chkatck1.wav");
+    sound_missile_launch    = gi_soundindex("chick/chkatck2.wav");
+    sound_melee_swing       = gi_soundindex("chick/chkatck3.wav");
+    sound_melee_hit         = gi_soundindex("chick/chkatck4.wav");
+    sound_missile_reload    = gi_soundindex("chick/chkatck5.wav");
+    sound_death1            = gi_soundindex("chick/chkdeth1.wav");
+    sound_death2            = gi_soundindex("chick/chkdeth2.wav");
+    sound_fall_down         = gi_soundindex("chick/chkfall1.wav");
+    sound_idle1             = gi_soundindex("chick/chkidle1.wav");
+    sound_idle2             = gi_soundindex("chick/chkidle2.wav");
+    sound_pain1             = gi_soundindex("chick/chkpain1.wav");
+    sound_pain2             = gi_soundindex("chick/chkpain2.wav");
+    sound_pain3             = gi_soundindex("chick/chkpain3.wav");
+    sound_sight             = gi_soundindex("chick/chksght1.wav");
+    sound_search            = gi_soundindex("chick/chksrch1.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/bitch/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/bitch/tris.md2");
     VectorSet(self->mins, -16, -16, 0);
     VectorSet(self->maxs, 16, 16, 56);
 
@@ -635,7 +635,7 @@ void SP_monster_chick(edict_t *self)
     self->monsterinfo.melee = chick_melee;
     self->monsterinfo.sight = chick_sight;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &chick_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_flipper.c
+++ b/src/baseq2/m_flipper.c
@@ -178,7 +178,7 @@ void flipper_bite(edict_t *self)
 
 void flipper_preattack(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_chomp, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_chomp, 1, ATTN_NORM, 0);
 }
 
 mframe_t flipper_frames_attack [] = {
@@ -227,10 +227,10 @@ void flipper_pain(edict_t *self, edict_t *other, float kick, int damage)
 
     n = (Q_rand() + 1) % 2;
     if (n == 0) {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &flipper_move_pain1;
     } else {
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &flipper_move_pain2;
     }
 }
@@ -242,7 +242,7 @@ void flipper_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t flipper_frames_death [] = {
@@ -312,7 +312,7 @@ mmove_t flipper_move_death = {FRAME_flpdth01, FRAME_flpdth56, flipper_frames_dea
 
 void flipper_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void flipper_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
@@ -321,7 +321,7 @@ void flipper_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 2; n++)
@@ -335,7 +335,7 @@ void flipper_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
         return;
 
 // regular death
-    gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.currentmove = &flipper_move_death;
@@ -350,18 +350,18 @@ void SP_monster_flipper(edict_t *self)
         return;
     }
 
-    sound_pain1     = gi.soundindex("flipper/flppain1.wav");
-    sound_pain2     = gi.soundindex("flipper/flppain2.wav");
-    sound_death     = gi.soundindex("flipper/flpdeth1.wav");
-    sound_chomp     = gi.soundindex("flipper/flpatck1.wav");
-    sound_attack    = gi.soundindex("flipper/flpatck2.wav");
-    sound_idle      = gi.soundindex("flipper/flpidle1.wav");
-    sound_search    = gi.soundindex("flipper/flpsrch1.wav");
-    sound_sight     = gi.soundindex("flipper/flpsght1.wav");
+    sound_pain1     = gi_soundindex("flipper/flppain1.wav");
+    sound_pain2     = gi_soundindex("flipper/flppain2.wav");
+    sound_death     = gi_soundindex("flipper/flpdeth1.wav");
+    sound_chomp     = gi_soundindex("flipper/flpatck1.wav");
+    sound_attack    = gi_soundindex("flipper/flpatck2.wav");
+    sound_idle      = gi_soundindex("flipper/flpidle1.wav");
+    sound_search    = gi_soundindex("flipper/flpsrch1.wav");
+    sound_sight     = gi_soundindex("flipper/flpsght1.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/flipper/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/flipper/tris.md2");
     VectorSet(self->mins, -16, -16, 0);
     VectorSet(self->maxs, 16, 16, 32);
 
@@ -378,7 +378,7 @@ void SP_monster_flipper(edict_t *self)
     self->monsterinfo.melee = flipper_melee;
     self->monsterinfo.sight = flipper_sight;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &flipper_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_float.c
+++ b/src/baseq2/m_float.c
@@ -38,12 +38,12 @@ static int  sound_sight;
 
 void floater_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void floater_idle(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 
@@ -501,7 +501,7 @@ void floater_walk(edict_t *self)
 void floater_wham(edict_t *self)
 {
     static  vec3_t  aim = {MELEE_DISTANCE, 0, 0};
-    gi.sound(self, CHAN_WEAPON, sound_attack3, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_attack3, 1, ATTN_NORM, 0);
     fire_hit(self, aim, 5 + Q_rand() % 6, -50);
 }
 
@@ -520,16 +520,16 @@ void floater_zap(edict_t *self)
     G_ProjectSource(self->s.origin, offset, forward, right, origin);
 //  G_ProjectSource (self->s.origin, monster_flash_offset[flash_number], forward, right, origin);
 
-    gi.sound(self, CHAN_WEAPON, sound_attack2, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_attack2, 1, ATTN_NORM, 0);
 
     //FIXME use the flash, Luke
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_SPLASH);
-    gi.WriteByte(32);
-    gi.WritePosition(origin);
-    gi.WriteDir(dir);
-    gi.WriteByte(1);    //sparks
-    gi.multicast(origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_SPLASH);
+    gi_WriteByte(32);
+    gi_WritePosition(origin);
+    gi_WriteDir(dir);
+    gi_WriteByte(1);    //sparks
+    gi_multicast(origin, MULTICAST_PVS);
 
     T_Damage(self->enemy, self, self, dir, self->enemy->s.origin, vec3_origin, 5 + Q_rand() % 6, -10, DAMAGE_ENERGY, MOD_UNKNOWN);
 }
@@ -565,10 +565,10 @@ void floater_pain(edict_t *self, edict_t *other, float kick, int damage)
 
     n = (Q_rand() + 1) % 3;
     if (n == 0) {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &floater_move_pain1;
     } else {
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &floater_move_pain2;
     }
 }
@@ -580,12 +580,12 @@ void floater_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void floater_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
-    gi.sound(self, CHAN_VOICE, sound_death1, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_death1, 1, ATTN_NORM, 0);
     BecomeExplosion1(self);
 }
 
@@ -598,21 +598,21 @@ void SP_monster_floater(edict_t *self)
         return;
     }
 
-    sound_attack2 = gi.soundindex("floater/fltatck2.wav");
-    sound_attack3 = gi.soundindex("floater/fltatck3.wav");
-    sound_death1 = gi.soundindex("floater/fltdeth1.wav");
-    sound_idle = gi.soundindex("floater/fltidle1.wav");
-    sound_pain1 = gi.soundindex("floater/fltpain1.wav");
-    sound_pain2 = gi.soundindex("floater/fltpain2.wav");
-    sound_sight = gi.soundindex("floater/fltsght1.wav");
+    sound_attack2 = gi_soundindex("floater/fltatck2.wav");
+    sound_attack3 = gi_soundindex("floater/fltatck3.wav");
+    sound_death1 = gi_soundindex("floater/fltdeth1.wav");
+    sound_idle = gi_soundindex("floater/fltidle1.wav");
+    sound_pain1 = gi_soundindex("floater/fltpain1.wav");
+    sound_pain2 = gi_soundindex("floater/fltpain2.wav");
+    sound_sight = gi_soundindex("floater/fltsght1.wav");
 
-    gi.soundindex("floater/fltatck1.wav");
+    gi_soundindex("floater/fltatck1.wav");
 
-    self->s.sound = gi.soundindex("floater/fltsrch1.wav");
+    self->s.sound = gi_soundindex("floater/fltsrch1.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/float/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/float/tris.md2");
     VectorSet(self->mins, -24, -24, -24);
     VectorSet(self->maxs, 24, 24, 32);
 
@@ -632,7 +632,7 @@ void SP_monster_floater(edict_t *self)
     self->monsterinfo.sight = floater_sight;
     self->monsterinfo.idle = floater_idle;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     if (random() <= 0.5f)
         self->monsterinfo.currentmove = &floater_move_stand1;

--- a/src/baseq2/m_flyer.c
+++ b/src/baseq2/m_flyer.c
@@ -49,17 +49,17 @@ void flyer_nextmove(edict_t *self);
 
 void flyer_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void flyer_idle(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 void flyer_pop_blades(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_sproing, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sproing, 1, ATTN_NORM, 0);
 }
 
 
@@ -410,7 +410,7 @@ void flyer_slash_left(edict_t *self)
 
     VectorSet(aim, MELEE_DISTANCE, self->mins[0], 0);
     fire_hit(self, aim, 5, 0);
-    gi.sound(self, CHAN_WEAPON, sound_slash, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_slash, 1, ATTN_NORM, 0);
 }
 
 void flyer_slash_right(edict_t *self)
@@ -419,7 +419,7 @@ void flyer_slash_right(edict_t *self)
 
     VectorSet(aim, MELEE_DISTANCE, self->maxs[0], 0);
     fire_hit(self, aim, 5, 0);
-    gi.sound(self, CHAN_WEAPON, sound_slash, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_slash, 1, ATTN_NORM, 0);
 }
 
 mframe_t flyer_frames_start_melee [] = {
@@ -525,13 +525,13 @@ void flyer_pain(edict_t *self, edict_t *other, float kick, int damage)
 
     n = Q_rand() % 3;
     if (n == 0) {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &flyer_move_pain1;
     } else if (n == 1) {
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &flyer_move_pain2;
     } else {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &flyer_move_pain3;
     }
 }
@@ -539,7 +539,7 @@ void flyer_pain(edict_t *self, edict_t *other, float kick, int damage)
 
 void flyer_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
-    gi.sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
     BecomeExplosion1(self);
 }
 
@@ -559,23 +559,23 @@ void SP_monster_flyer(edict_t *self)
         self->target = NULL;
     }
 
-    sound_sight = gi.soundindex("flyer/flysght1.wav");
-    sound_idle = gi.soundindex("flyer/flysrch1.wav");
-    sound_pain1 = gi.soundindex("flyer/flypain1.wav");
-    sound_pain2 = gi.soundindex("flyer/flypain2.wav");
-    sound_slash = gi.soundindex("flyer/flyatck2.wav");
-    sound_sproing = gi.soundindex("flyer/flyatck1.wav");
-    sound_die = gi.soundindex("flyer/flydeth1.wav");
+    sound_sight = gi_soundindex("flyer/flysght1.wav");
+    sound_idle = gi_soundindex("flyer/flysrch1.wav");
+    sound_pain1 = gi_soundindex("flyer/flypain1.wav");
+    sound_pain2 = gi_soundindex("flyer/flypain2.wav");
+    sound_slash = gi_soundindex("flyer/flyatck2.wav");
+    sound_sproing = gi_soundindex("flyer/flyatck1.wav");
+    sound_die = gi_soundindex("flyer/flydeth1.wav");
 
-    gi.soundindex("flyer/flyatck3.wav");
+    gi_soundindex("flyer/flyatck3.wav");
 
-    self->s.modelindex = gi.modelindex("models/monsters/flyer/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/flyer/tris.md2");
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
 
-    self->s.sound = gi.soundindex("flyer/flyidle1.wav");
+    self->s.sound = gi_soundindex("flyer/flyidle1.wav");
 
     self->health = 50;
     self->mass = 50;
@@ -591,7 +591,7 @@ void SP_monster_flyer(edict_t *self)
     self->monsterinfo.sight = flyer_sight;
     self->monsterinfo.idle = flyer_idle;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &flyer_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_gladiator.c
+++ b/src/baseq2/m_gladiator.c
@@ -41,22 +41,22 @@ static int  sound_sight;
 
 void gladiator_idle(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 void gladiator_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void gladiator_search(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
 }
 
 void gladiator_cleaver_swing(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_cleaver_swing, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_cleaver_swing, 1, ATTN_NORM, 0);
 }
 
 mframe_t gladiator_frames_stand [] = {
@@ -127,9 +127,9 @@ void GaldiatorMelee(edict_t *self)
 
     VectorSet(aim, MELEE_DISTANCE, self->mins[0], -4);
     if (fire_hit(self, aim, (20 + (Q_rand() % 5)), 300))
-        gi.sound(self, CHAN_AUTO, sound_cleaver_hit, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_AUTO, sound_cleaver_hit, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_AUTO, sound_cleaver_miss, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_AUTO, sound_cleaver_miss, 1, ATTN_NORM, 0);
 }
 
 mframe_t gladiator_frames_attack_melee [] = {
@@ -200,7 +200,7 @@ void gladiator_attack(edict_t *self)
         return;
 
     // charge up the railgun
-    gi.sound(self, CHAN_WEAPON, sound_gun, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_gun, 1, ATTN_NORM, 0);
     VectorCopy(self->enemy->s.origin, self->pos1);  //save for aiming the shot
     self->pos1[2] += self->enemy->viewheight;
     self->monsterinfo.currentmove = &gladiator_move_attack_gun;
@@ -243,9 +243,9 @@ void gladiator_pain(edict_t *self, edict_t *other, float kick, int damage)
     self->pain_debounce_framenum = level.framenum + 3 * BASE_FRAMERATE;
 
     if (random() < 0.5f)
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
 
     if (skill->value == 3)
         return;     // no pain anims in nightmare
@@ -265,7 +265,7 @@ void gladiator_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t gladiator_frames_death [] = {
@@ -300,7 +300,7 @@ void gladiator_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int dam
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -314,7 +314,7 @@ void gladiator_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int dam
         return;
 
 // regular death
-    gi.sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
 
@@ -332,20 +332,20 @@ void SP_monster_gladiator(edict_t *self)
     }
 
 
-    sound_pain1 = gi.soundindex("gladiator/pain.wav");
-    sound_pain2 = gi.soundindex("gladiator/gldpain2.wav");
-    sound_die = gi.soundindex("gladiator/glddeth2.wav");
-    sound_gun = gi.soundindex("gladiator/railgun.wav");
-    sound_cleaver_swing = gi.soundindex("gladiator/melee1.wav");
-    sound_cleaver_hit = gi.soundindex("gladiator/melee2.wav");
-    sound_cleaver_miss = gi.soundindex("gladiator/melee3.wav");
-    sound_idle = gi.soundindex("gladiator/gldidle1.wav");
-    sound_search = gi.soundindex("gladiator/gldsrch1.wav");
-    sound_sight = gi.soundindex("gladiator/sight.wav");
+    sound_pain1 = gi_soundindex("gladiator/pain.wav");
+    sound_pain2 = gi_soundindex("gladiator/gldpain2.wav");
+    sound_die = gi_soundindex("gladiator/glddeth2.wav");
+    sound_gun = gi_soundindex("gladiator/railgun.wav");
+    sound_cleaver_swing = gi_soundindex("gladiator/melee1.wav");
+    sound_cleaver_hit = gi_soundindex("gladiator/melee2.wav");
+    sound_cleaver_miss = gi_soundindex("gladiator/melee3.wav");
+    sound_idle = gi_soundindex("gladiator/gldidle1.wav");
+    sound_search = gi_soundindex("gladiator/gldsrch1.wav");
+    sound_sight = gi_soundindex("gladiator/sight.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/gladiatr/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/gladiatr/tris.md2");
     VectorSet(self->mins, -32, -32, -24);
     VectorSet(self->maxs, 32, 32, 64);
 
@@ -366,7 +366,7 @@ void SP_monster_gladiator(edict_t *self)
     self->monsterinfo.idle = gladiator_idle;
     self->monsterinfo.search = gladiator_search;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
     self->monsterinfo.currentmove = &gladiator_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;
 

--- a/src/baseq2/m_gunner.c
+++ b/src/baseq2/m_gunner.c
@@ -38,17 +38,17 @@ static int  sound_sight;
 
 void gunner_idlesound(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 void gunner_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void gunner_search(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
 }
 
 
@@ -281,9 +281,9 @@ void gunner_pain(edict_t *self, edict_t *other, float kick, int damage)
     self->pain_debounce_framenum = level.framenum + 3 * BASE_FRAMERATE;
 
     if (Q_rand() & 1)
-        gi.sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
 
     if (skill->value == 3)
         return;     // no pain anims in nightmare
@@ -303,7 +303,7 @@ void gunner_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t gunner_frames_death [] = {
@@ -327,7 +327,7 @@ void gunner_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -341,7 +341,7 @@ void gunner_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
         return;
 
 // regular death
-    gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.currentmove = &gunner_move_death;
@@ -361,7 +361,7 @@ void gunner_duck_down(edict_t *self)
     self->maxs[2] -= 32;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.pause_framenum = level.framenum + 1 * BASE_FRAMERATE;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void gunner_duck_hold(edict_t *self)
@@ -377,7 +377,7 @@ void gunner_duck_up(edict_t *self)
     self->monsterinfo.aiflags &= ~AI_DUCKED;
     self->maxs[2] += 32;
     self->takedamage = DAMAGE_AIM;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t gunner_frames_duck [] = {
@@ -406,7 +406,7 @@ void gunner_dodge(edict_t *self, edict_t *attacker, float eta)
 
 void gunner_opengun(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_open, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_open, 1, ATTN_IDLE, 0);
 }
 
 void GunnerFire(edict_t *self)
@@ -563,20 +563,20 @@ void SP_monster_gunner(edict_t *self)
         return;
     }
 
-    sound_death = gi.soundindex("gunner/death1.wav");
-    sound_pain = gi.soundindex("gunner/gunpain2.wav");
-    sound_pain2 = gi.soundindex("gunner/gunpain1.wav");
-    sound_idle = gi.soundindex("gunner/gunidle1.wav");
-    sound_open = gi.soundindex("gunner/gunatck1.wav");
-    sound_search = gi.soundindex("gunner/gunsrch1.wav");
-    sound_sight = gi.soundindex("gunner/sight1.wav");
+    sound_death = gi_soundindex("gunner/death1.wav");
+    sound_pain = gi_soundindex("gunner/gunpain2.wav");
+    sound_pain2 = gi_soundindex("gunner/gunpain1.wav");
+    sound_idle = gi_soundindex("gunner/gunidle1.wav");
+    sound_open = gi_soundindex("gunner/gunatck1.wav");
+    sound_search = gi_soundindex("gunner/gunsrch1.wav");
+    sound_sight = gi_soundindex("gunner/sight1.wav");
 
-    gi.soundindex("gunner/gunatck2.wav");
-    gi.soundindex("gunner/gunatck3.wav");
+    gi_soundindex("gunner/gunatck2.wav");
+    gi_soundindex("gunner/gunatck3.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/gunner/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/gunner/tris.md2");
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
 
@@ -596,7 +596,7 @@ void SP_monster_gunner(edict_t *self)
     self->monsterinfo.sight = gunner_sight;
     self->monsterinfo.search = gunner_search;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &gunner_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_hover.c
+++ b/src/baseq2/m_hover.c
@@ -40,15 +40,15 @@ static int  sound_search2;
 
 void hover_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void hover_search(edict_t *self)
 {
     if (random() < 0.5f)
-        gi.sound(self, CHAN_VOICE, sound_search1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_search1, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_search2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_search2, 1, ATTN_NORM, 0);
 }
 
 
@@ -480,14 +480,14 @@ void hover_pain(edict_t *self, edict_t *other, float kick, int damage)
 
     if (damage <= 25) {
         if (random() < 0.5f) {
-            gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+            gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
             self->monsterinfo.currentmove = &hover_move_pain3;
         } else {
-            gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+            gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
             self->monsterinfo.currentmove = &hover_move_pain2;
         }
     } else {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &hover_move_pain1;
     }
 }
@@ -509,7 +509,7 @@ void hover_dead(edict_t *self)
     self->think = hover_deadthink;
     self->nextthink = level.framenum + 1;
     self->timestamp = level.framenum + 15 * BASE_FRAMERATE;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void hover_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
@@ -518,7 +518,7 @@ void hover_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 2; n++)
@@ -533,9 +533,9 @@ void hover_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
 
 // regular death
     if (random() < 0.5f)
-        gi.sound(self, CHAN_VOICE, sound_death1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_death1, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_death2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_death2, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.currentmove = &hover_move_death1;
@@ -550,21 +550,21 @@ void SP_monster_hover(edict_t *self)
         return;
     }
 
-    sound_pain1 = gi.soundindex("hover/hovpain1.wav");
-    sound_pain2 = gi.soundindex("hover/hovpain2.wav");
-    sound_death1 = gi.soundindex("hover/hovdeth1.wav");
-    sound_death2 = gi.soundindex("hover/hovdeth2.wav");
-    sound_sight = gi.soundindex("hover/hovsght1.wav");
-    sound_search1 = gi.soundindex("hover/hovsrch1.wav");
-    sound_search2 = gi.soundindex("hover/hovsrch2.wav");
+    sound_pain1 = gi_soundindex("hover/hovpain1.wav");
+    sound_pain2 = gi_soundindex("hover/hovpain2.wav");
+    sound_death1 = gi_soundindex("hover/hovdeth1.wav");
+    sound_death2 = gi_soundindex("hover/hovdeth2.wav");
+    sound_sight = gi_soundindex("hover/hovsght1.wav");
+    sound_search1 = gi_soundindex("hover/hovsrch1.wav");
+    sound_search2 = gi_soundindex("hover/hovsrch2.wav");
 
-    gi.soundindex("hover/hovatck1.wav");
+    gi_soundindex("hover/hovatck1.wav");
 
-    self->s.sound = gi.soundindex("hover/hovidle1.wav");
+    self->s.sound = gi_soundindex("hover/hovidle1.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/hover/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/hover/tris.md2");
     VectorSet(self->mins, -24, -24, -24);
     VectorSet(self->maxs, 24, 24, 32);
 
@@ -583,7 +583,7 @@ void SP_monster_hover(edict_t *self)
     self->monsterinfo.sight = hover_sight;
     self->monsterinfo.search = hover_search;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &hover_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_infantry.c
+++ b/src/baseq2/m_infantry.c
@@ -131,7 +131,7 @@ mmove_t infantry_move_fidget = {FRAME_stand01, FRAME_stand49, infantry_frames_fi
 void infantry_fidget(edict_t *self)
 {
     self->monsterinfo.currentmove = &infantry_move_fidget;
-    gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 mframe_t infantry_frames_walk [] = {
@@ -222,10 +222,10 @@ void infantry_pain(edict_t *self, edict_t *other, float kick, int damage)
     n = Q_rand() % 2;
     if (n == 0) {
         self->monsterinfo.currentmove = &infantry_move_pain1;
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
     } else {
         self->monsterinfo.currentmove = &infantry_move_pain2;
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
     }
 }
 
@@ -280,7 +280,7 @@ void InfantryMachineGun(edict_t *self)
 
 void infantry_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_BODY, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void infantry_dead(edict_t *self)
@@ -289,7 +289,7 @@ void infantry_dead(edict_t *self)
     VectorSet(self->maxs, 16, 16, -8);
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     M_FlyCheck(self);
 }
@@ -368,7 +368,7 @@ void infantry_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int dama
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -388,13 +388,13 @@ void infantry_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int dama
     n = Q_rand() % 3;
     if (n == 0) {
         self->monsterinfo.currentmove = &infantry_move_death1;
-        gi.sound(self, CHAN_VOICE, sound_die2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_die2, 1, ATTN_NORM, 0);
     } else if (n == 1) {
         self->monsterinfo.currentmove = &infantry_move_death2;
-        gi.sound(self, CHAN_VOICE, sound_die1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_die1, 1, ATTN_NORM, 0);
     } else {
         self->monsterinfo.currentmove = &infantry_move_death3;
-        gi.sound(self, CHAN_VOICE, sound_die2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_die2, 1, ATTN_NORM, 0);
     }
 }
 
@@ -407,7 +407,7 @@ void infantry_duck_down(edict_t *self)
     self->maxs[2] -= 32;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.pause_framenum = level.framenum + 1 * BASE_FRAMERATE;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void infantry_duck_hold(edict_t *self)
@@ -423,7 +423,7 @@ void infantry_duck_up(edict_t *self)
     self->monsterinfo.aiflags &= ~AI_DUCKED;
     self->maxs[2] += 32;
     self->takedamage = DAMAGE_AIM;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t infantry_frames_duck [] = {
@@ -451,7 +451,7 @@ void infantry_cock_gun(edict_t *self)
 {
     int     n;
 
-    gi.sound(self, CHAN_WEAPON, sound_weapon_cock, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_weapon_cock, 1, ATTN_NORM, 0);
     n = (Q_rand() & 15) + 3 + 7;
     self->monsterinfo.pause_framenum = level.framenum + n;
 }
@@ -488,7 +488,7 @@ mmove_t infantry_move_attack1 = {FRAME_attak101, FRAME_attak115, infantry_frames
 
 void infantry_swing(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_punch_swing, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_punch_swing, 1, ATTN_NORM, 0);
 }
 
 void infantry_smack(edict_t *self)
@@ -497,7 +497,7 @@ void infantry_smack(edict_t *self)
 
     VectorSet(aim, MELEE_DISTANCE, 0, 0);
     if (fire_hit(self, aim, (5 + (Q_rand() % 5)), 50))
-        gi.sound(self, CHAN_WEAPON, sound_punch_hit, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_punch_hit, 1, ATTN_NORM, 0);
 }
 
 mframe_t infantry_frames_attack2 [] = {
@@ -530,24 +530,24 @@ void SP_monster_infantry(edict_t *self)
         return;
     }
 
-    sound_pain1 = gi.soundindex("infantry/infpain1.wav");
-    sound_pain2 = gi.soundindex("infantry/infpain2.wav");
-    sound_die1 = gi.soundindex("infantry/infdeth1.wav");
-    sound_die2 = gi.soundindex("infantry/infdeth2.wav");
+    sound_pain1 = gi_soundindex("infantry/infpain1.wav");
+    sound_pain2 = gi_soundindex("infantry/infpain2.wav");
+    sound_die1 = gi_soundindex("infantry/infdeth1.wav");
+    sound_die2 = gi_soundindex("infantry/infdeth2.wav");
 
-    sound_gunshot = gi.soundindex("infantry/infatck1.wav");
-    sound_weapon_cock = gi.soundindex("infantry/infatck3.wav");
-    sound_punch_swing = gi.soundindex("infantry/infatck2.wav");
-    sound_punch_hit = gi.soundindex("infantry/melee2.wav");
+    sound_gunshot = gi_soundindex("infantry/infatck1.wav");
+    sound_weapon_cock = gi_soundindex("infantry/infatck3.wav");
+    sound_punch_swing = gi_soundindex("infantry/infatck2.wav");
+    sound_punch_hit = gi_soundindex("infantry/melee2.wav");
 
-    sound_sight = gi.soundindex("infantry/infsght1.wav");
-    sound_search = gi.soundindex("infantry/infsrch1.wav");
-    sound_idle = gi.soundindex("infantry/infidle1.wav");
+    sound_sight = gi_soundindex("infantry/infsght1.wav");
+    sound_search = gi_soundindex("infantry/infsrch1.wav");
+    sound_idle = gi_soundindex("infantry/infidle1.wav");
 
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/infantry/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/infantry/tris.md2");
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
 
@@ -567,7 +567,7 @@ void SP_monster_infantry(edict_t *self)
     self->monsterinfo.sight = infantry_sight;
     self->monsterinfo.idle = infantry_fidget;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &infantry_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_insane.c
+++ b/src/baseq2/m_insane.c
@@ -34,22 +34,22 @@ static int  sound_scream[8];
 
 void insane_fist(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_fist, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_fist, 1, ATTN_IDLE, 0);
 }
 
 void insane_shake(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_shake, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_shake, 1, ATTN_IDLE, 0);
 }
 
 void insane_moan(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_moan, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_moan, 1, ATTN_IDLE, 0);
 }
 
 void insane_scream(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_scream[Q_rand() % 8], 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_scream[Q_rand() % 8], 1, ATTN_IDLE, 0);
 }
 
 
@@ -474,7 +474,7 @@ void insane_pain(edict_t *self, edict_t *other, float kick, int damage)
         l = 75;
     else
         l = 100;
-    gi.sound(self, CHAN_VOICE, gi.soundindex(va("player/male/pain%i_%i.wav", l, r)), 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, gi_soundindex(va("player/male/pain%i_%i.wav", l, r)), 1, ATTN_IDLE, 0);
 
     if (skill->value == 3)
         return;     // no pain anims in nightmare
@@ -546,7 +546,7 @@ void insane_dead(edict_t *self)
     }
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -555,7 +555,7 @@ void insane_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
     int     n;
 
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_IDLE, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_IDLE, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -568,7 +568,7 @@ void insane_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
     if (self->deadflag == DEAD_DEAD)
         return;
 
-    gi.sound(self, CHAN_VOICE, gi.soundindex(va("player/male/death%i.wav", (Q_rand() % 4) + 1)), 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, gi_soundindex(va("player/male/death%i.wav", (Q_rand() % 4) + 1)), 1, ATTN_IDLE, 0);
 
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
@@ -595,21 +595,21 @@ void SP_misc_insane(edict_t *self)
         return;
     }
 
-    sound_fist = gi.soundindex("insane/insane11.wav");
-    sound_shake = gi.soundindex("insane/insane5.wav");
-    sound_moan = gi.soundindex("insane/insane7.wav");
-    sound_scream[0] = gi.soundindex("insane/insane1.wav");
-    sound_scream[1] = gi.soundindex("insane/insane2.wav");
-    sound_scream[2] = gi.soundindex("insane/insane3.wav");
-    sound_scream[3] = gi.soundindex("insane/insane4.wav");
-    sound_scream[4] = gi.soundindex("insane/insane6.wav");
-    sound_scream[5] = gi.soundindex("insane/insane8.wav");
-    sound_scream[6] = gi.soundindex("insane/insane9.wav");
-    sound_scream[7] = gi.soundindex("insane/insane10.wav");
+    sound_fist = gi_soundindex("insane/insane11.wav");
+    sound_shake = gi_soundindex("insane/insane5.wav");
+    sound_moan = gi_soundindex("insane/insane7.wav");
+    sound_scream[0] = gi_soundindex("insane/insane1.wav");
+    sound_scream[1] = gi_soundindex("insane/insane2.wav");
+    sound_scream[2] = gi_soundindex("insane/insane3.wav");
+    sound_scream[3] = gi_soundindex("insane/insane4.wav");
+    sound_scream[4] = gi_soundindex("insane/insane6.wav");
+    sound_scream[5] = gi_soundindex("insane/insane8.wav");
+    sound_scream[6] = gi_soundindex("insane/insane9.wav");
+    sound_scream[7] = gi_soundindex("insane/insane10.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/insane/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/insane/tris.md2");
 
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
@@ -636,7 +636,7 @@ void SP_misc_insane(edict_t *self)
 //  if (skin > 12)
 //      skin = 0;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     if (self->spawnflags & 16)              // Stand Ground
         self->monsterinfo.aiflags |= AI_STAND_GROUND;

--- a/src/baseq2/m_medic.c
+++ b/src/baseq2/m_medic.c
@@ -77,7 +77,7 @@ void medic_idle(edict_t *self)
 {
     edict_t *ent;
 
-    gi.sound(self, CHAN_VOICE, sound_idle1, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle1, 1, ATTN_IDLE, 0);
 
     ent = medic_FindDeadMonster(self);
     if (ent) {
@@ -92,7 +92,7 @@ void medic_search(edict_t *self)
 {
     edict_t *ent;
 
-    gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_search, 1, ATTN_IDLE, 0);
 
     if (!self->oldenemy) {
         ent = medic_FindDeadMonster(self);
@@ -108,7 +108,7 @@ void medic_search(edict_t *self)
 
 void medic_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 
@@ -315,10 +315,10 @@ void medic_pain(edict_t *self, edict_t *other, float kick, int damage)
 
     if (random() < 0.5f) {
         self->monsterinfo.currentmove = &medic_move_pain1;
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
     } else {
         self->monsterinfo.currentmove = &medic_move_pain2;
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
     }
 }
 
@@ -355,7 +355,7 @@ void medic_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t medic_frames_death [] = {
@@ -402,7 +402,7 @@ void medic_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -416,7 +416,7 @@ void medic_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage,
         return;
 
 // regular death
-    gi.sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
 
@@ -432,7 +432,7 @@ void medic_duck_down(edict_t *self)
     self->maxs[2] -= 32;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.pause_framenum = level.framenum + 1 * BASE_FRAMERATE;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void medic_duck_hold(edict_t *self)
@@ -448,7 +448,7 @@ void medic_duck_up(edict_t *self)
     self->monsterinfo.aiflags &= ~AI_DUCKED;
     self->maxs[2] += 32;
     self->takedamage = DAMAGE_AIM;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t medic_frames_duck [] = {
@@ -532,7 +532,7 @@ mmove_t medic_move_attackBlaster = {FRAME_attack1, FRAME_attack14, medic_frames_
 
 void medic_hook_launch(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_hook_launch, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_hook_launch, 1, ATTN_NORM, 0);
 }
 
 void ED_CallSpawn(edict_t *ent);
@@ -577,12 +577,12 @@ void medic_cable_attack(edict_t *self)
     if (fabsf(angles[0]) > 45)
         return;
 
-    tr = gi.trace(start, NULL, NULL, self->enemy->s.origin, self, MASK_SHOT);
+    tr = gi_trace(start, NULL, NULL, self->enemy->s.origin, self, MASK_SHOT);
     if (tr.fraction != 1.0f && tr.ent != self->enemy)
         return;
 
     if (self->s.frame == FRAME_attack43) {
-        gi.sound(self->enemy, CHAN_AUTO, sound_hook_hit, 1, ATTN_NORM, 0);
+        gi_sound(self->enemy, CHAN_AUTO, sound_hook_hit, 1, ATTN_NORM, 0);
         self->enemy->monsterinfo.aiflags |= AI_RESURRECTING;
     } else if (self->s.frame == FRAME_attack50) {
         self->enemy->spawnflags = 0;
@@ -605,7 +605,7 @@ void medic_cable_attack(edict_t *self)
         }
     } else {
         if (self->s.frame == FRAME_attack44)
-            gi.sound(self, CHAN_WEAPON, sound_hook_heal, 1, ATTN_NORM, 0);
+            gi_sound(self, CHAN_WEAPON, sound_hook_heal, 1, ATTN_NORM, 0);
     }
 
     // adjust start for beam origin being in middle of a segment
@@ -615,17 +615,17 @@ void medic_cable_attack(edict_t *self)
     VectorCopy(self->enemy->s.origin, end);
     end[2] = self->enemy->absmin[2] + self->enemy->size[2] / 2;
 
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_MEDIC_CABLE_ATTACK);
-    gi.WriteShort(self - g_edicts);
-    gi.WritePosition(start);
-    gi.WritePosition(end);
-    gi.multicast(self->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_MEDIC_CABLE_ATTACK);
+    gi_WriteShort(self - g_edicts);
+    gi_WritePosition(start);
+    gi_WritePosition(end);
+    gi_multicast(self->s.origin, MULTICAST_PVS);
 }
 
 void medic_hook_retract(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_hook_retract, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_hook_retract, 1, ATTN_NORM, 0);
     self->enemy->monsterinfo.aiflags &= ~AI_RESURRECTING;
 }
 
@@ -690,22 +690,22 @@ void SP_monster_medic(edict_t *self)
         return;
     }
 
-    sound_idle1 = gi.soundindex("medic/idle.wav");
-    sound_pain1 = gi.soundindex("medic/medpain1.wav");
-    sound_pain2 = gi.soundindex("medic/medpain2.wav");
-    sound_die = gi.soundindex("medic/meddeth1.wav");
-    sound_sight = gi.soundindex("medic/medsght1.wav");
-    sound_search = gi.soundindex("medic/medsrch1.wav");
-    sound_hook_launch = gi.soundindex("medic/medatck2.wav");
-    sound_hook_hit = gi.soundindex("medic/medatck3.wav");
-    sound_hook_heal = gi.soundindex("medic/medatck4.wav");
-    sound_hook_retract = gi.soundindex("medic/medatck5.wav");
+    sound_idle1 = gi_soundindex("medic/idle.wav");
+    sound_pain1 = gi_soundindex("medic/medpain1.wav");
+    sound_pain2 = gi_soundindex("medic/medpain2.wav");
+    sound_die = gi_soundindex("medic/meddeth1.wav");
+    sound_sight = gi_soundindex("medic/medsght1.wav");
+    sound_search = gi_soundindex("medic/medsrch1.wav");
+    sound_hook_launch = gi_soundindex("medic/medatck2.wav");
+    sound_hook_hit = gi_soundindex("medic/medatck3.wav");
+    sound_hook_heal = gi_soundindex("medic/medatck4.wav");
+    sound_hook_retract = gi_soundindex("medic/medatck5.wav");
 
-    gi.soundindex("medic/medatck1.wav");
+    gi_soundindex("medic/medatck1.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/medic/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/medic/tris.md2");
     VectorSet(self->mins, -24, -24, -24);
     VectorSet(self->maxs, 24, 24, 32);
 
@@ -727,7 +727,7 @@ void SP_monster_medic(edict_t *self)
     self->monsterinfo.search = medic_search;
     self->monsterinfo.checkattack = medic_checkattack;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &medic_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_move.c
+++ b/src/baseq2/m_move.c
@@ -50,7 +50,7 @@ bool M_CheckBottom(edict_t *ent)
         for (y = 0 ; y <= 1 ; y++) {
             start[0] = x ? maxs[0] : mins[0];
             start[1] = y ? maxs[1] : mins[1];
-            if (gi.pointcontents(start) != CONTENTS_SOLID)
+            if (gi_pointcontents(start) != CONTENTS_SOLID)
                 goto realcheck;
         }
 
@@ -68,7 +68,7 @@ realcheck:
     start[0] = stop[0] = (mins[0] + maxs[0]) * 0.5f;
     start[1] = stop[1] = (mins[1] + maxs[1]) * 0.5f;
     stop[2] = start[2] - 2 * STEPSIZE;
-    trace = gi.trace(start, vec3_origin, vec3_origin, stop, ent, MASK_MONSTERSOLID);
+    trace = gi_trace(start, vec3_origin, vec3_origin, stop, ent, MASK_MONSTERSOLID);
 
     if (trace.fraction == 1.0f)
         return false;
@@ -80,7 +80,7 @@ realcheck:
             start[0] = stop[0] = x ? maxs[0] : mins[0];
             start[1] = stop[1] = y ? maxs[1] : mins[1];
 
-            trace = gi.trace(start, vec3_origin, vec3_origin, stop, ent, MASK_MONSTERSOLID);
+            trace = gi_trace(start, vec3_origin, vec3_origin, stop, ent, MASK_MONSTERSOLID);
 
             if (trace.fraction != 1.0f && trace.endpos[2] > bottom)
                 bottom = trace.endpos[2];
@@ -145,7 +145,7 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
                         neworg[2] += dz;
                 }
             }
-            trace = gi.trace(ent->s.origin, ent->mins, ent->maxs, neworg, ent, MASK_MONSTERSOLID);
+            trace = gi_trace(ent->s.origin, ent->mins, ent->maxs, neworg, ent, MASK_MONSTERSOLID);
 
             // fly monsters don't enter water voluntarily
             if (ent->flags & FL_FLY) {
@@ -153,7 +153,7 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
                     test[0] = trace.endpos[0];
                     test[1] = trace.endpos[1];
                     test[2] = trace.endpos[2] + ent->mins[2] + 1;
-                    contents = gi.pointcontents(test);
+                    contents = gi_pointcontents(test);
                     if (contents & MASK_WATER)
                         return false;
                 }
@@ -165,7 +165,7 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
                     test[0] = trace.endpos[0];
                     test[1] = trace.endpos[1];
                     test[2] = trace.endpos[2] + ent->mins[2] + 1;
-                    contents = gi.pointcontents(test);
+                    contents = gi_pointcontents(test);
                     if (!(contents & MASK_WATER))
                         return false;
                 }
@@ -174,7 +174,7 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
             if (trace.fraction == 1) {
                 VectorCopy(trace.endpos, ent->s.origin);
                 if (relink) {
-                    gi.linkentity(ent);
+                    gi_linkentity(ent);
                     G_TouchTriggers(ent);
                 }
                 return true;
@@ -197,14 +197,14 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
     VectorCopy(neworg, end);
     end[2] -= stepsize * 2;
 
-    trace = gi.trace(neworg, ent->mins, ent->maxs, end, ent, MASK_MONSTERSOLID);
+    trace = gi_trace(neworg, ent->mins, ent->maxs, end, ent, MASK_MONSTERSOLID);
 
     if (trace.allsolid)
         return false;
 
     if (trace.startsolid) {
         neworg[2] -= stepsize;
-        trace = gi.trace(neworg, ent->mins, ent->maxs, end, ent, MASK_MONSTERSOLID);
+        trace = gi_trace(neworg, ent->mins, ent->maxs, end, ent, MASK_MONSTERSOLID);
         if (trace.allsolid || trace.startsolid)
             return false;
     }
@@ -215,7 +215,7 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
         test[0] = trace.endpos[0];
         test[1] = trace.endpos[1];
         test[2] = trace.endpos[2] + ent->mins[2] + 1;
-        contents = gi.pointcontents(test);
+        contents = gi_pointcontents(test);
 
         if (contents & MASK_WATER)
             return false;
@@ -226,7 +226,7 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
         if (ent->flags & FL_PARTIALGROUND) {
             VectorAdd(ent->s.origin, move, ent->s.origin);
             if (relink) {
-                gi.linkentity(ent);
+                gi_linkentity(ent);
                 G_TouchTriggers(ent);
             }
             ent->groundentity = NULL;
@@ -244,7 +244,7 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
             // entity had floor mostly pulled out from underneath it
             // and is trying to correct
             if (relink) {
-                gi.linkentity(ent);
+                gi_linkentity(ent);
                 G_TouchTriggers(ent);
             }
             return true;
@@ -261,7 +261,7 @@ bool SV_movestep(edict_t *ent, vec3_t move, bool relink)
 
 // the move is ok
     if (relink) {
-        gi.linkentity(ent);
+        gi_linkentity(ent);
         G_TouchTriggers(ent);
     }
     return true;
@@ -339,11 +339,11 @@ bool SV_StepDirection(edict_t *ent, float yaw, float dist)
             // not turned far enough, so don't take the step
             VectorCopy(oldorigin, ent->s.origin);
         }
-        gi.linkentity(ent);
+        gi_linkentity(ent);
         G_TouchTriggers(ent);
         return true;
     }
-    gi.linkentity(ent);
+    gi_linkentity(ent);
     G_TouchTriggers(ent);
     return false;
 }

--- a/src/baseq2/m_mutant.c
+++ b/src/baseq2/m_mutant.c
@@ -50,26 +50,26 @@ void mutant_step(edict_t *self)
     int     n;
     n = (Q_rand() + 1) % 3;
     if (n == 0)
-        gi.sound(self, CHAN_VOICE, sound_step1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_step1, 1, ATTN_NORM, 0);
     else if (n == 1)
-        gi.sound(self, CHAN_VOICE, sound_step2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_step2, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_step3, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_step3, 1, ATTN_NORM, 0);
 }
 
 void mutant_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void mutant_search(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
 }
 
 void mutant_swing(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_swing, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_swing, 1, ATTN_NORM, 0);
 }
 
 
@@ -173,7 +173,7 @@ mmove_t mutant_move_idle = {FRAME_stand152, FRAME_stand164, mutant_frames_idle, 
 void mutant_idle(edict_t *self)
 {
     self->monsterinfo.currentmove = &mutant_move_idle;
-    gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 
@@ -251,9 +251,9 @@ void mutant_hit_left(edict_t *self)
 
     VectorSet(aim, MELEE_DISTANCE, self->mins[0], 8);
     if (fire_hit(self, aim, (10 + (Q_rand() % 5)), 100))
-        gi.sound(self, CHAN_WEAPON, sound_hit, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_hit, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_WEAPON, sound_swing, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_swing, 1, ATTN_NORM, 0);
 }
 
 void mutant_hit_right(edict_t *self)
@@ -262,9 +262,9 @@ void mutant_hit_right(edict_t *self)
 
     VectorSet(aim, MELEE_DISTANCE, self->maxs[0], 8);
     if (fire_hit(self, aim, (10 + (Q_rand() % 5)), 100))
-        gi.sound(self, CHAN_WEAPON, sound_hit2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_hit2, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_WEAPON, sound_swing, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_swing, 1, ATTN_NORM, 0);
 }
 
 void mutant_check_refire(edict_t *self)
@@ -333,7 +333,7 @@ void mutant_jump_takeoff(edict_t *self)
 {
     vec3_t  forward;
 
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
     AngleVectors(self->s.angles, forward, NULL, NULL);
     self->s.origin[2] += 1;
     VectorScale(forward, 600, self->velocity);
@@ -347,7 +347,7 @@ void mutant_jump_takeoff(edict_t *self)
 void mutant_check_landing(edict_t *self)
 {
     if (self->groundentity) {
-        gi.sound(self, CHAN_WEAPON, sound_thud, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_thud, 1, ATTN_NORM, 0);
         self->monsterinfo.attack_finished = 0;
         self->monsterinfo.aiflags &= ~AI_DUCKED;
         return;
@@ -489,13 +489,13 @@ void mutant_pain(edict_t *self, edict_t *other, float kick, int damage)
 
     r = random();
     if (r < 0.33f) {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &mutant_move_pain1;
     } else if (r < 0.66f) {
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &mutant_move_pain2;
     } else {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &mutant_move_pain3;
     }
 }
@@ -511,7 +511,7 @@ void mutant_dead(edict_t *self)
     VectorSet(self->maxs, 16, 16, -8);
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     M_FlyCheck(self);
 }
@@ -548,7 +548,7 @@ void mutant_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
     int     n;
 
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -561,7 +561,7 @@ void mutant_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
     if (self->deadflag == DEAD_DEAD)
         return;
 
-    gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
     self->s.skinnum = 1;
@@ -586,23 +586,23 @@ void SP_monster_mutant(edict_t *self)
         return;
     }
 
-    sound_swing = gi.soundindex("mutant/mutatck1.wav");
-    sound_hit = gi.soundindex("mutant/mutatck2.wav");
-    sound_hit2 = gi.soundindex("mutant/mutatck3.wav");
-    sound_death = gi.soundindex("mutant/mutdeth1.wav");
-    sound_idle = gi.soundindex("mutant/mutidle1.wav");
-    sound_pain1 = gi.soundindex("mutant/mutpain1.wav");
-    sound_pain2 = gi.soundindex("mutant/mutpain2.wav");
-    sound_sight = gi.soundindex("mutant/mutsght1.wav");
-    sound_search = gi.soundindex("mutant/mutsrch1.wav");
-    sound_step1 = gi.soundindex("mutant/step1.wav");
-    sound_step2 = gi.soundindex("mutant/step2.wav");
-    sound_step3 = gi.soundindex("mutant/step3.wav");
-    sound_thud = gi.soundindex("mutant/thud1.wav");
+    sound_swing = gi_soundindex("mutant/mutatck1.wav");
+    sound_hit = gi_soundindex("mutant/mutatck2.wav");
+    sound_hit2 = gi_soundindex("mutant/mutatck3.wav");
+    sound_death = gi_soundindex("mutant/mutdeth1.wav");
+    sound_idle = gi_soundindex("mutant/mutidle1.wav");
+    sound_pain1 = gi_soundindex("mutant/mutpain1.wav");
+    sound_pain2 = gi_soundindex("mutant/mutpain2.wav");
+    sound_sight = gi_soundindex("mutant/mutsght1.wav");
+    sound_search = gi_soundindex("mutant/mutsrch1.wav");
+    sound_step1 = gi_soundindex("mutant/step1.wav");
+    sound_step2 = gi_soundindex("mutant/step2.wav");
+    sound_step3 = gi_soundindex("mutant/step3.wav");
+    sound_thud = gi_soundindex("mutant/thud1.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/mutant/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/mutant/tris.md2");
     VectorSet(self->mins, -32, -32, -24);
     VectorSet(self->maxs, 32, 32, 48);
 
@@ -624,7 +624,7 @@ void SP_monster_mutant(edict_t *self)
     self->monsterinfo.idle = mutant_idle;
     self->monsterinfo.checkattack = mutant_checkattack;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &mutant_move_stand;
 

--- a/src/baseq2/m_parasite.c
+++ b/src/baseq2/m_parasite.c
@@ -52,32 +52,32 @@ void parasite_refidget(edict_t *self);
 
 void parasite_launch(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_launch, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_launch, 1, ATTN_NORM, 0);
 }
 
 void parasite_reel_in(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_reelin, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_reelin, 1, ATTN_NORM, 0);
 }
 
 void parasite_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_WEAPON, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_sight, 1, ATTN_NORM, 0);
 }
 
 void parasite_tap(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_tap, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_WEAPON, sound_tap, 1, ATTN_IDLE, 0);
 }
 
 void parasite_scratch(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_scratch, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_WEAPON, sound_scratch, 1, ATTN_IDLE, 0);
 }
 
 void parasite_search(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_search, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_WEAPON, sound_search, 1, ATTN_IDLE, 0);
 }
 
 
@@ -273,9 +273,9 @@ void parasite_pain(edict_t *self, edict_t *other, float kick, int damage)
         return;     // no pain anims in nightmare
 
     if (random() < 0.5f)
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
 
     self->monsterinfo.currentmove = &parasite_move_pain1;
 }
@@ -321,25 +321,25 @@ void parasite_drain_attack(edict_t *self)
     }
     VectorCopy(self->enemy->s.origin, end);
 
-    tr = gi.trace(start, NULL, NULL, end, self, MASK_SHOT);
+    tr = gi_trace(start, NULL, NULL, end, self, MASK_SHOT);
     if (tr.ent != self->enemy)
         return;
 
     if (self->s.frame == FRAME_drain03) {
         damage = 5;
-        gi.sound(self->enemy, CHAN_AUTO, sound_impact, 1, ATTN_NORM, 0);
+        gi_sound(self->enemy, CHAN_AUTO, sound_impact, 1, ATTN_NORM, 0);
     } else {
         if (self->s.frame == FRAME_drain04)
-            gi.sound(self, CHAN_WEAPON, sound_suck, 1, ATTN_NORM, 0);
+            gi_sound(self, CHAN_WEAPON, sound_suck, 1, ATTN_NORM, 0);
         damage = 2;
     }
 
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_PARASITE_ATTACK);
-    gi.WriteShort(self - g_edicts);
-    gi.WritePosition(start);
-    gi.WritePosition(end);
-    gi.multicast(self->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_PARASITE_ATTACK);
+    gi_WriteShort(self - g_edicts);
+    gi_WritePosition(start);
+    gi_WritePosition(end);
+    gi_multicast(self->s.origin, MULTICAST_PVS);
 
     VectorSubtract(start, end, dir);
     T_Damage(self->enemy, self, self, dir, self->enemy->s.origin, vec3_origin, damage, 0, DAMAGE_NO_KNOCKBACK, MOD_UNKNOWN);
@@ -433,7 +433,7 @@ void parasite_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t parasite_frames_death [] = {
@@ -453,7 +453,7 @@ void parasite_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int dama
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 2; n++)
             ThrowGib(self, "models/objects/gibs/bone/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -467,7 +467,7 @@ void parasite_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int dama
         return;
 
 // regular death
-    gi.sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.currentmove = &parasite_move_death;
@@ -488,19 +488,19 @@ void SP_monster_parasite(edict_t *self)
         return;
     }
 
-    sound_pain1 = gi.soundindex("parasite/parpain1.wav");
-    sound_pain2 = gi.soundindex("parasite/parpain2.wav");
-    sound_die = gi.soundindex("parasite/pardeth1.wav");
-    sound_launch = gi.soundindex("parasite/paratck1.wav");
-    sound_impact = gi.soundindex("parasite/paratck2.wav");
-    sound_suck = gi.soundindex("parasite/paratck3.wav");
-    sound_reelin = gi.soundindex("parasite/paratck4.wav");
-    sound_sight = gi.soundindex("parasite/parsght1.wav");
-    sound_tap = gi.soundindex("parasite/paridle1.wav");
-    sound_scratch = gi.soundindex("parasite/paridle2.wav");
-    sound_search = gi.soundindex("parasite/parsrch1.wav");
+    sound_pain1 = gi_soundindex("parasite/parpain1.wav");
+    sound_pain2 = gi_soundindex("parasite/parpain2.wav");
+    sound_die = gi_soundindex("parasite/pardeth1.wav");
+    sound_launch = gi_soundindex("parasite/paratck1.wav");
+    sound_impact = gi_soundindex("parasite/paratck2.wav");
+    sound_suck = gi_soundindex("parasite/paratck3.wav");
+    sound_reelin = gi_soundindex("parasite/paratck4.wav");
+    sound_sight = gi_soundindex("parasite/parsght1.wav");
+    sound_tap = gi_soundindex("parasite/paridle1.wav");
+    sound_scratch = gi_soundindex("parasite/paridle2.wav");
+    sound_search = gi_soundindex("parasite/parsrch1.wav");
 
-    self->s.modelindex = gi.modelindex("models/monsters/parasite/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/parasite/tris.md2");
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 24);
     self->movetype = MOVETYPE_STEP;
@@ -520,7 +520,7 @@ void SP_monster_parasite(edict_t *self)
     self->monsterinfo.sight = parasite_sight;
     self->monsterinfo.idle = parasite_idle;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &parasite_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_soldier.c
+++ b/src/baseq2/m_soldier.c
@@ -42,15 +42,15 @@ static int  sound_cock;
 void soldier_idle(edict_t *self)
 {
     if (random() > 0.8f)
-        gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+        gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 void soldier_cock(edict_t *self)
 {
     if (self->s.frame == FRAME_stand322)
-        gi.sound(self, CHAN_WEAPON, sound_cock, 1, ATTN_IDLE, 0);
+        gi_sound(self, CHAN_WEAPON, sound_cock, 1, ATTN_IDLE, 0);
     else
-        gi.sound(self, CHAN_WEAPON, sound_cock, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_WEAPON, sound_cock, 1, ATTN_NORM, 0);
 }
 
 
@@ -407,11 +407,11 @@ void soldier_pain(edict_t *self, edict_t *other, float kick, int damage)
 
     n = self->s.skinnum | 1;
     if (n == 1)
-        gi.sound(self, CHAN_VOICE, sound_pain_light, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain_light, 1, ATTN_NORM, 0);
     else if (n == 3)
-        gi.sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_pain_ss, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain_ss, 1, ATTN_NORM, 0);
 
     if (self->velocity[2] > 100) {
         self->monsterinfo.currentmove = &soldier_move_pain4;
@@ -610,7 +610,7 @@ void soldier_duck_down(edict_t *self)
     self->maxs[2] -= 32;
     self->takedamage = DAMAGE_YES;
     self->monsterinfo.pause_framenum = level.framenum + 1 * BASE_FRAMERATE;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void soldier_duck_up(edict_t *self)
@@ -618,7 +618,7 @@ void soldier_duck_up(edict_t *self)
     self->monsterinfo.aiflags &= ~AI_DUCKED;
     self->maxs[2] += 32;
     self->takedamage = DAMAGE_AIM;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 void soldier_fire3(edict_t *self)
@@ -756,9 +756,9 @@ void soldier_attack(edict_t *self)
 void soldier_sight(edict_t *self, edict_t *other)
 {
     if (random() < 0.5f)
-        gi.sound(self, CHAN_VOICE, sound_sight1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_sight1, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_sight2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_sight2, 1, ATTN_NORM, 0);
 
     if ((skill->value > 0) && (range(self, self->enemy) >= RANGE_MID)) {
         if (random() > 0.5f)
@@ -847,7 +847,7 @@ void soldier_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t soldier_frames_death1 [] = {
@@ -1100,7 +1100,7 @@ void soldier_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 3; n++)
             ThrowGib(self, "models/objects/gibs/sm_meat/tris.md2", damage, GIB_ORGANIC);
         ThrowGib(self, "models/objects/gibs/chest/tris.md2", damage, GIB_ORGANIC);
@@ -1118,11 +1118,11 @@ void soldier_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
     self->s.skinnum |= 1;
 
     if (self->s.skinnum == 1)
-        gi.sound(self, CHAN_VOICE, sound_death_light, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_death_light, 1, ATTN_NORM, 0);
     else if (self->s.skinnum == 3)
-        gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
     else // (self->s.skinnum == 5)
-        gi.sound(self, CHAN_VOICE, sound_death_ss, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_death_ss, 1, ATTN_NORM, 0);
 
     if (fabsf((self->s.origin[2] + self->viewheight) - point[2]) <= 4) {
         // head shot
@@ -1151,17 +1151,17 @@ void soldier_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
 void SP_monster_soldier_x(edict_t *self)
 {
 
-    self->s.modelindex = gi.modelindex("models/monsters/soldier/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/soldier/tris.md2");
     self->monsterinfo.scale = MODEL_SCALE;
     VectorSet(self->mins, -16, -16, -24);
     VectorSet(self->maxs, 16, 16, 32);
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
 
-    sound_idle =    gi.soundindex("soldier/solidle1.wav");
-    sound_sight1 =  gi.soundindex("soldier/solsght1.wav");
-    sound_sight2 =  gi.soundindex("soldier/solsrch1.wav");
-    sound_cock =    gi.soundindex("infantry/infatck3.wav");
+    sound_idle =    gi_soundindex("soldier/solidle1.wav");
+    sound_sight1 =  gi_soundindex("soldier/solsght1.wav");
+    sound_sight2 =  gi_soundindex("soldier/solsrch1.wav");
+    sound_cock =    gi_soundindex("infantry/infatck3.wav");
 
     self->mass = 100;
 
@@ -1176,7 +1176,7 @@ void SP_monster_soldier_x(edict_t *self)
     self->monsterinfo.melee = NULL;
     self->monsterinfo.sight = soldier_sight;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.stand(self);
 
@@ -1195,11 +1195,11 @@ void SP_monster_soldier_light(edict_t *self)
 
     SP_monster_soldier_x(self);
 
-    sound_pain_light = gi.soundindex("soldier/solpain2.wav");
-    sound_death_light = gi.soundindex("soldier/soldeth2.wav");
-    gi.modelindex("models/objects/laser/tris.md2");
-    gi.soundindex("misc/lasfly.wav");
-    gi.soundindex("soldier/solatck2.wav");
+    sound_pain_light = gi_soundindex("soldier/solpain2.wav");
+    sound_death_light = gi_soundindex("soldier/soldeth2.wav");
+    gi_modelindex("models/objects/laser/tris.md2");
+    gi_soundindex("misc/lasfly.wav");
+    gi_soundindex("soldier/solatck2.wav");
 
     self->s.skinnum = 0;
     self->health = 20;
@@ -1217,9 +1217,9 @@ void SP_monster_soldier(edict_t *self)
 
     SP_monster_soldier_x(self);
 
-    sound_pain = gi.soundindex("soldier/solpain1.wav");
-    sound_death = gi.soundindex("soldier/soldeth1.wav");
-    gi.soundindex("soldier/solatck1.wav");
+    sound_pain = gi_soundindex("soldier/solpain1.wav");
+    sound_death = gi_soundindex("soldier/soldeth1.wav");
+    gi_soundindex("soldier/solatck1.wav");
 
     self->s.skinnum = 2;
     self->health = 30;
@@ -1237,9 +1237,9 @@ void SP_monster_soldier_ss(edict_t *self)
 
     SP_monster_soldier_x(self);
 
-    sound_pain_ss = gi.soundindex("soldier/solpain3.wav");
-    sound_death_ss = gi.soundindex("soldier/soldeth3.wav");
-    gi.soundindex("soldier/solatck3.wav");
+    sound_pain_ss = gi_soundindex("soldier/solpain3.wav");
+    sound_death_ss = gi_soundindex("soldier/soldeth3.wav");
+    gi_soundindex("soldier/solatck3.wav");
 
     self->s.skinnum = 4;
     self->health = 40;

--- a/src/baseq2/m_supertank.c
+++ b/src/baseq2/m_supertank.c
@@ -41,15 +41,15 @@ void BossExplode(edict_t *self);
 
 void TreadSound(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, tread_sound, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, tread_sound, 1, ATTN_NORM, 0);
 }
 
 void supertank_search(edict_t *self)
 {
     if (random() < 0.5f)
-        gi.sound(self, CHAN_VOICE, sound_search1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_search1, 1, ATTN_NORM, 0);
     else
-        gi.sound(self, CHAN_VOICE, sound_search2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_search2, 1, ATTN_NORM, 0);
 }
 
 
@@ -457,13 +457,13 @@ void supertank_pain(edict_t *self, edict_t *other, float kick, int damage)
         return;     // no pain anims in nightmare
 
     if (damage <= 10) {
-        gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &supertank_move_pain1;
     } else if (damage <= 25) {
-        gi.sound(self, CHAN_VOICE, sound_pain3, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain3, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &supertank_move_pain2;
     } else {
-        gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
         self->monsterinfo.currentmove = &supertank_move_pain3;
     }
 }
@@ -562,7 +562,7 @@ void supertank_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 
@@ -619,10 +619,10 @@ void BossExplode(edict_t *self)
         return;
     }
 
-    gi.WriteByte(svc_temp_entity);
-    gi.WriteByte(TE_EXPLOSION1);
-    gi.WritePosition(org);
-    gi.multicast(self->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_temp_entity);
+    gi_WriteByte(TE_EXPLOSION1);
+    gi_WritePosition(org);
+    gi_multicast(self->s.origin, MULTICAST_PVS);
 
     self->nextthink = level.framenum + 1;
 }
@@ -630,7 +630,7 @@ void BossExplode(edict_t *self)
 
 void supertank_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
-    gi.sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_death, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_NO;
     self->count = 0;
@@ -650,19 +650,19 @@ void SP_monster_supertank(edict_t *self)
         return;
     }
 
-    sound_pain1 = gi.soundindex("bosstank/btkpain1.wav");
-    sound_pain2 = gi.soundindex("bosstank/btkpain2.wav");
-    sound_pain3 = gi.soundindex("bosstank/btkpain3.wav");
-    sound_death = gi.soundindex("bosstank/btkdeth1.wav");
-    sound_search1 = gi.soundindex("bosstank/btkunqv1.wav");
-    sound_search2 = gi.soundindex("bosstank/btkunqv2.wav");
+    sound_pain1 = gi_soundindex("bosstank/btkpain1.wav");
+    sound_pain2 = gi_soundindex("bosstank/btkpain2.wav");
+    sound_pain3 = gi_soundindex("bosstank/btkpain3.wav");
+    sound_death = gi_soundindex("bosstank/btkdeth1.wav");
+    sound_search1 = gi_soundindex("bosstank/btkunqv1.wav");
+    sound_search2 = gi_soundindex("bosstank/btkunqv2.wav");
 
-//  self->s.sound = gi.soundindex ("bosstank/btkengn1.wav");
-    tread_sound = gi.soundindex("bosstank/btkengn1.wav");
+//  self->s.sound = gi_soundindex ("bosstank/btkengn1.wav");
+    tread_sound = gi_soundindex("bosstank/btkengn1.wav");
 
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
-    self->s.modelindex = gi.modelindex("models/monsters/boss1/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/boss1/tris.md2");
     VectorSet(self->mins, -64, -64, 0);
     VectorSet(self->maxs, 64, 64, 112);
 
@@ -681,7 +681,7 @@ void SP_monster_supertank(edict_t *self)
     self->monsterinfo.melee = NULL;
     self->monsterinfo.sight = NULL;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &supertank_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/m_tank.c
+++ b/src/baseq2/m_tank.c
@@ -46,28 +46,28 @@ static int  sound_strike;
 
 void tank_sight(edict_t *self, edict_t *other)
 {
-    gi.sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_sight, 1, ATTN_NORM, 0);
 }
 
 
 void tank_footstep(edict_t *self)
 {
-    gi.sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
 }
 
 void tank_thud(edict_t *self)
 {
-    gi.sound(self, CHAN_BODY, sound_thud, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_BODY, sound_thud, 1, ATTN_NORM, 0);
 }
 
 void tank_windup(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_windup, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_windup, 1, ATTN_NORM, 0);
 }
 
 void tank_idle(edict_t *self)
 {
-    gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+    gi_sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
 
@@ -293,7 +293,7 @@ void tank_pain(edict_t *self, edict_t *other, float kick, int damage)
     }
 
     self->pain_debounce_framenum = level.framenum + 3 * BASE_FRAMERATE;
-    gi.sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
 
     if (skill->value == 3)
         return;     // no pain anims in nightmare
@@ -338,7 +338,7 @@ void TankBlaster(edict_t *self)
 
 void TankStrike(edict_t *self)
 {
-    gi.sound(self, CHAN_WEAPON, sound_strike, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_WEAPON, sound_strike, 1, ATTN_NORM, 0);
 }
 
 void TankRocket(edict_t *self)
@@ -672,7 +672,7 @@ void tank_dead(edict_t *self)
     self->movetype = MOVETYPE_TOSS;
     self->svflags |= SVF_DEADMONSTER;
     self->nextthink = 0;
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 mframe_t tank_frames_death1 [] = {
@@ -717,7 +717,7 @@ void tank_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, 
 
 // check for gib
     if (self->health <= self->gib_health) {
-        gi.sound(self, CHAN_VOICE, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_VOICE, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 1 /*4*/; n++)
             ThrowGib(self, "models/objects/gibs/sm_meat/tris.md2", damage, GIB_ORGANIC);
         for (n = 0; n < 4; n++)
@@ -732,7 +732,7 @@ void tank_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, 
         return;
 
 // regular death
-    gi.sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
+    gi_sound(self, CHAN_VOICE, sound_die, 1, ATTN_NORM, 0);
     self->deadflag = DEAD_DEAD;
     self->takedamage = DAMAGE_YES;
 
@@ -756,28 +756,28 @@ void SP_monster_tank(edict_t *self)
         return;
     }
 
-    self->s.modelindex = gi.modelindex("models/monsters/tank/tris.md2");
+    self->s.modelindex = gi_modelindex("models/monsters/tank/tris.md2");
     VectorSet(self->mins, -32, -32, -16);
     VectorSet(self->maxs, 32, 32, 72);
     self->movetype = MOVETYPE_STEP;
     self->solid = SOLID_BBOX;
 
-    sound_pain = gi.soundindex("tank/tnkpain2.wav");
-    sound_thud = gi.soundindex("tank/tnkdeth2.wav");
-    sound_idle = gi.soundindex("tank/tnkidle1.wav");
-    sound_die = gi.soundindex("tank/death.wav");
-    sound_step = gi.soundindex("tank/step.wav");
-    sound_windup = gi.soundindex("tank/tnkatck4.wav");
-    sound_strike = gi.soundindex("tank/tnkatck5.wav");
-    sound_sight = gi.soundindex("tank/sight1.wav");
+    sound_pain = gi_soundindex("tank/tnkpain2.wav");
+    sound_thud = gi_soundindex("tank/tnkdeth2.wav");
+    sound_idle = gi_soundindex("tank/tnkidle1.wav");
+    sound_die = gi_soundindex("tank/death.wav");
+    sound_step = gi_soundindex("tank/step.wav");
+    sound_windup = gi_soundindex("tank/tnkatck4.wav");
+    sound_strike = gi_soundindex("tank/tnkatck5.wav");
+    sound_sight = gi_soundindex("tank/sight1.wav");
 
-    gi.soundindex("tank/tnkatck1.wav");
-    gi.soundindex("tank/tnkatk2a.wav");
-    gi.soundindex("tank/tnkatk2b.wav");
-    gi.soundindex("tank/tnkatk2c.wav");
-    gi.soundindex("tank/tnkatk2d.wav");
-    gi.soundindex("tank/tnkatk2e.wav");
-    gi.soundindex("tank/tnkatck3.wav");
+    gi_soundindex("tank/tnkatck1.wav");
+    gi_soundindex("tank/tnkatk2a.wav");
+    gi_soundindex("tank/tnkatk2b.wav");
+    gi_soundindex("tank/tnkatk2c.wav");
+    gi_soundindex("tank/tnkatk2d.wav");
+    gi_soundindex("tank/tnkatk2e.wav");
+    gi_soundindex("tank/tnkatck3.wav");
 
     if (strcmp(self->classname, "monster_tank_commander") == 0) {
         self->health = 1000;
@@ -800,7 +800,7 @@ void SP_monster_tank(edict_t *self)
     self->monsterinfo.sight = tank_sight;
     self->monsterinfo.idle = tank_idle;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 
     self->monsterinfo.currentmove = &tank_move_stand;
     self->monsterinfo.scale = MODEL_SCALE;

--- a/src/baseq2/p_client.c
+++ b/src/baseq2/p_client.c
@@ -50,7 +50,7 @@ void SP_FixCoopSpots(edict_t *self)
         VectorSubtract(self->s.origin, spot->s.origin, d);
         if (VectorLength(d) < 384) {
             if ((!self->targetname) || Q_stricmp(self->targetname, spot->targetname) != 0) {
-//              gi.dprintf("FixCoopSpots changed %s at %s targetname from %s to %s\n", self->classname, vtos(self->s.origin), self->targetname, spot->targetname);
+//              gi_dprintf("FixCoopSpots changed %s at %s targetname from %s to %s\n", self->classname, vtos(self->s.origin), self->targetname, spot->targetname);
                 self->targetname = spot->targetname;
             }
             return;
@@ -158,7 +158,7 @@ void SP_info_player_coop(edict_t *self)
 The deathmatch intermission point will be at one of these
 Use 'angles' instead of 'angle', so you can set pitch or roll as well as yaw.  'pitch yaw roll'
 */
-void SP_info_player_intermission(void)
+void SP_info_player_intermission(edict_t *ent)
 {
 }
 
@@ -288,7 +288,7 @@ void ClientObituary(edict_t *self, edict_t *inflictor, edict_t *attacker)
             }
         }
         if (message) {
-            gi.bprintf(PRINT_MEDIUM, "%s %s.\n", self->client->pers.netname, message);
+            gi_bprintf(PRINT_MEDIUM, "%s %s.\n", self->client->pers.netname, message);
             if (deathmatch->value)
                 self->client->resp.score--;
             self->enemy = NULL;
@@ -368,7 +368,7 @@ void ClientObituary(edict_t *self, edict_t *inflictor, edict_t *attacker)
                 break;
             }
             if (message) {
-                gi.bprintf(PRINT_MEDIUM, "%s %s %s%s\n", self->client->pers.netname, message, attacker->client->pers.netname, message2);
+                gi_bprintf(PRINT_MEDIUM, "%s %s %s%s\n", self->client->pers.netname, message, attacker->client->pers.netname, message2);
                 if (deathmatch->value) {
                     if (ff)
                         attacker->client->resp.score--;
@@ -380,7 +380,7 @@ void ClientObituary(edict_t *self, edict_t *inflictor, edict_t *attacker)
         }
     }
 
-    gi.bprintf(PRINT_MEDIUM, "%s died.\n", self->client->pers.netname);
+    gi_bprintf(PRINT_MEDIUM, "%s died.\n", self->client->pers.netname);
     if (deathmatch->value)
         self->client->resp.score--;
 }
@@ -521,7 +521,7 @@ void player_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
 
     if (self->health < -40) {
         // gib
-        gi.sound(self, CHAN_BODY, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_BODY, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 4; n++)
             ThrowGib(self, "models/objects/gibs/sm_meat/tris.md2", damage, GIB_ORGANIC);
         ThrowClientHead(self, damage);
@@ -552,13 +552,13 @@ void player_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
                     self->client->anim_end = FRAME_death308;
                     break;
                 }
-            gi.sound(self, CHAN_VOICE, gi.soundindex(va("*death%i.wav", (Q_rand() % 4) + 1)), 1, ATTN_NORM, 0);
+            gi_sound(self, CHAN_VOICE, gi_soundindex(va("*death%i.wav", (Q_rand() % 4) + 1)), 1, ATTN_NORM, 0);
         }
     }
 
     self->deadflag = DEAD_DEAD;
 
-    gi.linkentity(self);
+    gi_linkentity(self);
 }
 
 //=======================================================================
@@ -854,7 +854,7 @@ void    SelectSpawnPoint(edict_t *ent, vec3_t origin, vec3_t angles)
                 spot = G_Find(spot, FOFS(classname), "info_player_start");
             }
             if (!spot)
-                gi.error("Couldn't find spawn point %s", game.spawnpoint);
+                gi_error("Couldn't find spawn point %s", game.spawnpoint);
         }
     }
 
@@ -883,7 +883,7 @@ void body_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, 
     int n;
 
     if (self->health < -40) {
-        gi.sound(self, CHAN_BODY, gi.soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
+        gi_sound(self, CHAN_BODY, gi_soundindex("misc/udeath.wav"), 1, ATTN_NORM, 0);
         for (n = 0; n < 4; n++)
             ThrowGib(self, "models/objects/gibs/sm_meat/tris.md2", damage, GIB_ORGANIC);
         self->s.origin[2] -= 48;
@@ -896,7 +896,7 @@ void CopyToBodyQue(edict_t *ent)
 {
     edict_t     *body;
 
-    gi.unlinkentity(ent);
+    gi_unlinkentity(ent);
 
     // grab a body que and cycle to the next one
     body = &g_edicts[game.maxclients + level.body_que + 1];
@@ -904,14 +904,14 @@ void CopyToBodyQue(edict_t *ent)
 
     // send an effect on the removed body
     if (body->s.modelindex) {
-        gi.WriteByte(svc_temp_entity);
-        gi.WriteByte(TE_BLOOD);
-        gi.WritePosition(body->s.origin);
-        gi.WriteDir(vec3_origin);
-        gi.multicast(body->s.origin, MULTICAST_PVS);
+        gi_WriteByte(svc_temp_entity);
+        gi_WriteByte(TE_BLOOD);
+        gi_WritePosition(body->s.origin);
+        gi_WriteDir(vec3_origin);
+        gi_multicast(body->s.origin, MULTICAST_PVS);
     }
 
-    gi.unlinkentity(body);
+    gi_unlinkentity(body);
     body->s = ent->s;
     body->s.number = body - g_edicts;
     body->s.event = EV_OTHER_TELEPORT;
@@ -933,7 +933,7 @@ void CopyToBodyQue(edict_t *ent)
     body->die = body_die;
     body->takedamage = DAMAGE_YES;
 
-    gi.linkentity(body);
+    gi_linkentity(body);
 }
 
 void respawn(edict_t *self)
@@ -958,7 +958,7 @@ void respawn(edict_t *self)
     }
 
     // restart the entire server
-    gi.AddCommandString("pushmenu loadgame\n");
+    gi_AddCommandString("pushmenu loadgame\n");
 }
 
 /*
@@ -977,11 +977,11 @@ void spectator_respawn(edict_t *ent)
         if (*spectator_password->string &&
             strcmp(spectator_password->string, "none") &&
             strcmp(spectator_password->string, value)) {
-            gi.cprintf(ent, PRINT_HIGH, "Spectator password incorrect.\n");
+            gi_cprintf(ent, PRINT_HIGH, "Spectator password incorrect.\n");
             ent->client->pers.spectator = false;
-            gi.WriteByte(svc_stufftext);
-            gi.WriteString("spectator 0\n");
-            gi.unicast(ent, true);
+            gi_WriteByte(svc_stufftext);
+            gi_WriteString("spectator 0\n");
+            gi_unicast(ent, true);
             return;
         }
 
@@ -991,12 +991,12 @@ void spectator_respawn(edict_t *ent)
                 numspec++;
 
         if (numspec >= maxspectators->value) {
-            gi.cprintf(ent, PRINT_HIGH, "Server spectator limit is full.");
+            gi_cprintf(ent, PRINT_HIGH, "Server spectator limit is full.");
             ent->client->pers.spectator = false;
             // reset his spectator var
-            gi.WriteByte(svc_stufftext);
-            gi.WriteString("spectator 0\n");
-            gi.unicast(ent, true);
+            gi_WriteByte(svc_stufftext);
+            gi_WriteString("spectator 0\n");
+            gi_unicast(ent, true);
             return;
         }
     } else {
@@ -1005,11 +1005,11 @@ void spectator_respawn(edict_t *ent)
         char *value = Info_ValueForKey(ent->client->pers.userinfo, "password");
         if (*password->string && strcmp(password->string, "none") &&
             strcmp(password->string, value)) {
-            gi.cprintf(ent, PRINT_HIGH, "Password incorrect.\n");
+            gi_cprintf(ent, PRINT_HIGH, "Password incorrect.\n");
             ent->client->pers.spectator = true;
-            gi.WriteByte(svc_stufftext);
-            gi.WriteString("spectator 1\n");
-            gi.unicast(ent, true);
+            gi_WriteByte(svc_stufftext);
+            gi_WriteString("spectator 1\n");
+            gi_unicast(ent, true);
             return;
         }
     }
@@ -1023,10 +1023,10 @@ void spectator_respawn(edict_t *ent)
     // add a teleportation effect
     if (!ent->client->pers.spectator)  {
         // send effect
-        gi.WriteByte(svc_muzzleflash);
-        gi.WriteShort(ent - g_edicts);
-        gi.WriteByte(MZ_LOGIN);
-        gi.multicast(ent->s.origin, MULTICAST_PVS);
+        gi_WriteByte(svc_muzzleflash);
+        gi_WriteShort(ent - g_edicts);
+        gi_WriteByte(MZ_LOGIN);
+        gi_multicast(ent->s.origin, MULTICAST_PVS);
 
         // hold in place briefly
         ent->client->ps.pmove.pm_flags = PMF_TIME_TELEPORT;
@@ -1036,9 +1036,9 @@ void spectator_respawn(edict_t *ent)
     ent->client->respawn_framenum = level.framenum;
 
     if (ent->client->pers.spectator)
-        gi.bprintf(PRINT_HIGH, "%s has moved to the sidelines\n", ent->client->pers.netname);
+        gi_bprintf(PRINT_HIGH, "%s has moved to the sidelines\n", ent->client->pers.netname);
     else
-        gi.bprintf(PRINT_HIGH, "%s joined the game\n", ent->client->pers.netname);
+        gi_bprintf(PRINT_HIGH, "%s joined the game\n", ent->client->pers.netname);
 }
 
 //==============================================================
@@ -1154,7 +1154,7 @@ void PutClientInServer(edict_t *ent)
             client->ps.fov = 160;
     }
 
-    client->ps.gunindex = gi.modelindex(client->pers.weapon->view_model);
+    client->ps.gunindex = gi_modelindex(client->pers.weapon->view_model);
 
     // clear entity state values
     ent->s.effects = 0;
@@ -1190,7 +1190,7 @@ void PutClientInServer(edict_t *ent)
         ent->solid = SOLID_NOT;
         ent->svflags |= SVF_NOCLIENT;
         ent->client->ps.gunindex = 0;
-        gi.linkentity(ent);
+        gi_linkentity(ent);
         return;
     } else
         client->resp.spectator = false;
@@ -1199,7 +1199,7 @@ void PutClientInServer(edict_t *ent)
         // could't spawn in?
     }
 
-    gi.linkentity(ent);
+    gi_linkentity(ent);
 
     // force the current weapon up
     client->newweapon = client->pers.weapon;
@@ -1227,13 +1227,13 @@ void ClientBeginDeathmatch(edict_t *ent)
         MoveClientToIntermission(ent);
     } else {
         // send effect
-        gi.WriteByte(svc_muzzleflash);
-        gi.WriteShort(ent - g_edicts);
-        gi.WriteByte(MZ_LOGIN);
-        gi.multicast(ent->s.origin, MULTICAST_PVS);
+        gi_WriteByte(svc_muzzleflash);
+        gi_WriteShort(ent - g_edicts);
+        gi_WriteByte(MZ_LOGIN);
+        gi_multicast(ent->s.origin, MULTICAST_PVS);
     }
 
-    gi.bprintf(PRINT_HIGH, "%s entered the game\n", ent->client->pers.netname);
+    gi_bprintf(PRINT_HIGH, "%s entered the game\n", ent->client->pers.netname);
 
     // make sure all view stuff is valid
     ClientEndServerFrame(ent);
@@ -1283,12 +1283,12 @@ void ClientBegin(edict_t *ent)
     } else {
         // send effect if in a multiplayer game
         if (game.maxclients > 1) {
-            gi.WriteByte(svc_muzzleflash);
-            gi.WriteShort(ent - g_edicts);
-            gi.WriteByte(MZ_LOGIN);
-            gi.multicast(ent->s.origin, MULTICAST_PVS);
+            gi_WriteByte(svc_muzzleflash);
+            gi_WriteShort(ent - g_edicts);
+            gi_WriteByte(MZ_LOGIN);
+            gi_multicast(ent->s.origin, MULTICAST_PVS);
 
-            gi.bprintf(PRINT_HIGH, "%s entered the game\n", ent->client->pers.netname);
+            gi_bprintf(PRINT_HIGH, "%s entered the game\n", ent->client->pers.netname);
         }
     }
 
@@ -1334,7 +1334,7 @@ void ClientUserinfoChanged(edict_t *ent, char *userinfo)
     playernum = ent - g_edicts - 1;
 
     // combine name and skin into a configstring
-    gi.configstring(CS_PLAYERSKINS + playernum, va("%s\\%s", ent->client->pers.netname, s));
+    gi_configstring(CS_PLAYERSKINS + playernum, va("%s\\%s", ent->client->pers.netname, s));
 
     // fov
     if (deathmatch->value && ((int)dmflags->value & DF_FIXED_FOV)) {
@@ -1428,7 +1428,7 @@ qboolean ClientConnect(edict_t *ent, char *userinfo)
     ClientUserinfoChanged(ent, userinfo);
 
     if (game.maxclients > 1)
-        gi.dprintf("%s connected\n", ent->client->pers.netname);
+        gi_dprintf("%s connected\n", ent->client->pers.netname);
 
     ent->svflags = 0; // make sure we start with known default
     ent->client->pers.connected = true;
@@ -1450,17 +1450,17 @@ void ClientDisconnect(edict_t *ent)
     if (!ent->client)
         return;
 
-    gi.bprintf(PRINT_HIGH, "%s disconnected\n", ent->client->pers.netname);
+    gi_bprintf(PRINT_HIGH, "%s disconnected\n", ent->client->pers.netname);
 
     // send effect
     if (ent->inuse) {
-        gi.WriteByte(svc_muzzleflash);
-        gi.WriteShort(ent - g_edicts);
-        gi.WriteByte(MZ_LOGOUT);
-        gi.multicast(ent->s.origin, MULTICAST_PVS);
+        gi_WriteByte(svc_muzzleflash);
+        gi_WriteShort(ent - g_edicts);
+        gi_WriteByte(MZ_LOGOUT);
+        gi_multicast(ent->s.origin, MULTICAST_PVS);
     }
 
-    gi.unlinkentity(ent);
+    gi_unlinkentity(ent);
     ent->s.modelindex = 0;
     ent->s.sound = 0;
     ent->s.event = 0;
@@ -1472,7 +1472,7 @@ void ClientDisconnect(edict_t *ent)
 
     // FIXME: don't break skins on corpses, etc
     //playernum = ent-g_edicts-1;
-    //gi.configstring (CS_PLAYERSKINS+playernum, "");
+    //gi_configstring (CS_PLAYERSKINS+playernum, "");
 }
 
 
@@ -1485,9 +1485,9 @@ edict_t *pm_passent;
 trace_t q_gameabi PM_trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end)
 {
     if (pm_passent->health > 0)
-        return gi.trace(start, mins, maxs, end, pm_passent, MASK_PLAYERSOLID);
+        return gi_trace(start, mins, maxs, end, pm_passent, MASK_PLAYERSOLID);
     else
-        return gi.trace(start, mins, maxs, end, pm_passent, MASK_DEADSOLID);
+        return gi_trace(start, mins, maxs, end, pm_passent, MASK_DEADSOLID);
 }
 
 unsigned CheckBlock(void *b, int c)
@@ -1566,16 +1566,16 @@ void ClientThink(edict_t *ent, usercmd_t *ucmd)
 
         if (memcmp(&client->old_pmove, &pm.s, sizeof(pm.s))) {
             pm.snapinitial = true;
-            //      gi.dprintf ("pmove changed!\n");
+            //      gi_dprintf ("pmove changed!\n");
         }
 
         pm.cmd = *ucmd;
 
         pm.trace = PM_trace;    // adds default parms
-        pm.pointcontents = gi.pointcontents;
+        pm.pointcontents = gi_pointcontents;
 
         // perform a pmove
-        gi.Pmove(&pm);
+        gi_Pmove(&pm);
 
         // save results of pmove
         client->ps.pmove = pm.s;
@@ -1594,7 +1594,7 @@ void ClientThink(edict_t *ent, usercmd_t *ucmd)
         client->resp.cmd_angles[2] = SHORT2ANGLE(ucmd->angles[2]);
 
         if (ent->groundentity && !pm.groundentity && (pm.cmd.upmove >= 10) && (pm.waterlevel == 0)) {
-            gi.sound(ent, CHAN_VOICE, gi.soundindex("*jump1.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_VOICE, gi_soundindex("*jump1.wav"), 1, ATTN_NORM, 0);
             PlayerNoise(ent, ent->s.origin, PNOISE_SELF);
         }
 
@@ -1614,7 +1614,7 @@ void ClientThink(edict_t *ent, usercmd_t *ucmd)
             VectorCopy(pm.viewangles, client->ps.viewangles);
         }
 
-        gi.linkentity(ent);
+        gi_linkentity(ent);
 
         if (ent->movetype != MOVETYPE_NOCLIP)
             G_TouchTriggers(ent);

--- a/src/baseq2/p_hud.c
+++ b/src/baseq2/p_hud.c
@@ -62,7 +62,7 @@ void MoveClientToIntermission(edict_t *ent)
 
     if (deathmatch->value || coop->value) {
         DeathmatchScoreboardMessage(ent, NULL);
-        gi.unicast(ent, true);
+        gi_unicast(ent, true);
     }
 
 }
@@ -225,8 +225,8 @@ void DeathmatchScoreboardMessage(edict_t *ent, edict_t *killer)
         stringlength += j;
     }
 
-    gi.WriteByte(svc_layout);
-    gi.WriteString(string);
+    gi_WriteByte(svc_layout);
+    gi_WriteString(string);
 }
 
 
@@ -241,7 +241,7 @@ Note that it isn't that hard to overflow the 1400 byte message limit!
 void DeathmatchScoreboard(edict_t *ent)
 {
     DeathmatchScoreboardMessage(ent, ent->enemy);
-    gi.unicast(ent, true);
+    gi_unicast(ent, true);
 }
 
 
@@ -308,9 +308,9 @@ void HelpComputer(edict_t *ent)
                level.found_goals, level.total_goals,
                level.found_secrets, level.total_secrets);
 
-    gi.WriteByte(svc_layout);
-    gi.WriteString(string);
-    gi.unicast(ent, true);
+    gi_WriteByte(svc_layout);
+    gi_WriteString(string);
+    gi_unicast(ent, true);
 }
 
 
@@ -370,7 +370,7 @@ void G_SetStats(edict_t *ent)
         ent->client->ps.stats[STAT_AMMO] = 0;
     } else {
         item = &itemlist[ent->client->ammo_index];
-        ent->client->ps.stats[STAT_AMMO_ICON] = gi.imageindex(item->icon);
+        ent->client->ps.stats[STAT_AMMO_ICON] = gi_imageindex(item->icon);
         ent->client->ps.stats[STAT_AMMO] = ent->client->pers.inventory[ent->client->ammo_index];
     }
 
@@ -383,7 +383,7 @@ void G_SetStats(edict_t *ent)
         if (cells == 0) {
             // ran out of cells for power armor
             ent->flags &= ~FL_POWER_ARMOR;
-            gi.sound(ent, CHAN_ITEM, gi.soundindex("misc/power2.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_ITEM, gi_soundindex("misc/power2.wav"), 1, ATTN_NORM, 0);
             power_armor_type = 0;;
         }
     }
@@ -391,11 +391,11 @@ void G_SetStats(edict_t *ent)
     index = ArmorIndex(ent);
     if (power_armor_type && (!index || (level.framenum & 8))) {
         // flash between power armor and other armor icon
-        ent->client->ps.stats[STAT_ARMOR_ICON] = gi.imageindex("i_powershield");
+        ent->client->ps.stats[STAT_ARMOR_ICON] = gi_imageindex("i_powershield");
         ent->client->ps.stats[STAT_ARMOR] = cells;
     } else if (index) {
         item = GetItemByIndex(index);
-        ent->client->ps.stats[STAT_ARMOR_ICON] = gi.imageindex(item->icon);
+        ent->client->ps.stats[STAT_ARMOR_ICON] = gi_imageindex(item->icon);
         ent->client->ps.stats[STAT_ARMOR] = ent->client->pers.inventory[index];
     } else {
         ent->client->ps.stats[STAT_ARMOR_ICON] = 0;
@@ -414,16 +414,16 @@ void G_SetStats(edict_t *ent)
     // timers
     //
     if (ent->client->quad_framenum > level.framenum) {
-        ent->client->ps.stats[STAT_TIMER_ICON] = gi.imageindex("p_quad");
+        ent->client->ps.stats[STAT_TIMER_ICON] = gi_imageindex("p_quad");
         ent->client->ps.stats[STAT_TIMER] = (ent->client->quad_framenum - level.framenum) / 10;
     } else if (ent->client->invincible_framenum > level.framenum) {
-        ent->client->ps.stats[STAT_TIMER_ICON] = gi.imageindex("p_invulnerability");
+        ent->client->ps.stats[STAT_TIMER_ICON] = gi_imageindex("p_invulnerability");
         ent->client->ps.stats[STAT_TIMER] = (ent->client->invincible_framenum - level.framenum) / 10;
     } else if (ent->client->enviro_framenum > level.framenum) {
-        ent->client->ps.stats[STAT_TIMER_ICON] = gi.imageindex("p_envirosuit");
+        ent->client->ps.stats[STAT_TIMER_ICON] = gi_imageindex("p_envirosuit");
         ent->client->ps.stats[STAT_TIMER] = (ent->client->enviro_framenum - level.framenum) / 10;
     } else if (ent->client->breather_framenum > level.framenum) {
-        ent->client->ps.stats[STAT_TIMER_ICON] = gi.imageindex("p_rebreather");
+        ent->client->ps.stats[STAT_TIMER_ICON] = gi_imageindex("p_rebreather");
         ent->client->ps.stats[STAT_TIMER] = (ent->client->breather_framenum - level.framenum) / 10;
     } else {
         ent->client->ps.stats[STAT_TIMER_ICON] = 0;
@@ -436,7 +436,7 @@ void G_SetStats(edict_t *ent)
     if (ent->client->pers.selected_item == -1)
         ent->client->ps.stats[STAT_SELECTED_ICON] = 0;
     else
-        ent->client->ps.stats[STAT_SELECTED_ICON] = gi.imageindex(itemlist[ent->client->pers.selected_item].icon);
+        ent->client->ps.stats[STAT_SELECTED_ICON] = gi_imageindex(itemlist[ent->client->pers.selected_item].icon);
 
     ent->client->ps.stats[STAT_SELECTED_ITEM] = ent->client->pers.selected_item;
 
@@ -467,10 +467,10 @@ void G_SetStats(edict_t *ent)
     // help icon / current weapon if not shown
     //
     if (ent->client->pers.helpchanged && (level.framenum & 8))
-        ent->client->ps.stats[STAT_HELPICON] = gi.imageindex("i_help");
+        ent->client->ps.stats[STAT_HELPICON] = gi_imageindex("i_help");
     else if ((ent->client->pers.hand == CENTER_HANDED || ent->client->ps.fov > 91)
              && ent->client->pers.weapon)
-        ent->client->ps.stats[STAT_HELPICON] = gi.imageindex(ent->client->pers.weapon->icon);
+        ent->client->ps.stats[STAT_HELPICON] = gi_imageindex(ent->client->pers.weapon->icon);
     else
         ent->client->ps.stats[STAT_HELPICON] = 0;
 

--- a/src/baseq2/p_view.c
+++ b/src/baseq2/p_view.c
@@ -134,7 +134,7 @@ void P_DamageFeedback(edict_t *player)
             l = 75;
         else
             l = 100;
-        gi.sound(player, CHAN_VOICE, gi.soundindex(va("*pain%i_%i.wav", l, r)), 1, ATTN_NORM, 0);
+        gi_sound(player, CHAN_VOICE, gi_soundindex(va("*pain%i_%i.wav", l, r)), 1, ATTN_NORM, 0);
     }
 
     // the total alpha of the blend is always proportional to count
@@ -298,7 +298,7 @@ void SV_CalcViewOffset(edict_t *ent)
     bob = bobfracsin * xyspeed * bob_up->value;
     if (bob > 6)
         bob = 6;
-    //gi.DebugGraph (bob *2, 255);
+    //gi_DebugGraph (bob *2, 255);
     v[2] += bob;
 
     // add kick offset
@@ -410,7 +410,7 @@ void SV_CalcBlend(edict_t *ent)
 
     // add for contents
     VectorAdd(ent->s.origin, ent->client->ps.viewoffset, vieworg);
-    contents = gi.pointcontents(vieworg);
+    contents = gi_pointcontents(vieworg);
     if (contents & (CONTENTS_LAVA | CONTENTS_SLIME | CONTENTS_WATER))
         ent->client->ps.rdflags |= RDF_UNDERWATER;
     else
@@ -427,25 +427,25 @@ void SV_CalcBlend(edict_t *ent)
     if (ent->client->quad_framenum > level.framenum) {
         remaining = ent->client->quad_framenum - level.framenum;
         if (remaining == 30)    // beginning to fade
-            gi.sound(ent, CHAN_ITEM, gi.soundindex("items/damage2.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_ITEM, gi_soundindex("items/damage2.wav"), 1, ATTN_NORM, 0);
         if (remaining > 30 || (remaining & 4))
             SV_AddBlend(0, 0, 1, 0.08f, ent->client->ps.blend);
     } else if (ent->client->invincible_framenum > level.framenum) {
         remaining = ent->client->invincible_framenum - level.framenum;
         if (remaining == 30)    // beginning to fade
-            gi.sound(ent, CHAN_ITEM, gi.soundindex("items/protect2.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_ITEM, gi_soundindex("items/protect2.wav"), 1, ATTN_NORM, 0);
         if (remaining > 30 || (remaining & 4))
             SV_AddBlend(1, 1, 0, 0.08f, ent->client->ps.blend);
     } else if (ent->client->enviro_framenum > level.framenum) {
         remaining = ent->client->enviro_framenum - level.framenum;
         if (remaining == 30)    // beginning to fade
-            gi.sound(ent, CHAN_ITEM, gi.soundindex("items/airout.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_ITEM, gi_soundindex("items/airout.wav"), 1, ATTN_NORM, 0);
         if (remaining > 30 || (remaining & 4))
             SV_AddBlend(0, 1, 0, 0.08f, ent->client->ps.blend);
     } else if (ent->client->breather_framenum > level.framenum) {
         remaining = ent->client->breather_framenum - level.framenum;
         if (remaining == 30)    // beginning to fade
-            gi.sound(ent, CHAN_ITEM, gi.soundindex("items/airout.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_ITEM, gi_soundindex("items/airout.wav"), 1, ATTN_NORM, 0);
         if (remaining > 30 || (remaining & 4))
             SV_AddBlend(0.4f, 1, 0.4f, 0.04f, ent->client->ps.blend);
     }
@@ -569,11 +569,11 @@ void P_WorldEffects(void)
     if (!old_waterlevel && waterlevel) {
         PlayerNoise(current_player, current_player->s.origin, PNOISE_SELF);
         if (current_player->watertype & CONTENTS_LAVA)
-            gi.sound(current_player, CHAN_BODY, gi.soundindex("player/lava_in.wav"), 1, ATTN_NORM, 0);
+            gi_sound(current_player, CHAN_BODY, gi_soundindex("player/lava_in.wav"), 1, ATTN_NORM, 0);
         else if (current_player->watertype & CONTENTS_SLIME)
-            gi.sound(current_player, CHAN_BODY, gi.soundindex("player/watr_in.wav"), 1, ATTN_NORM, 0);
+            gi_sound(current_player, CHAN_BODY, gi_soundindex("player/watr_in.wav"), 1, ATTN_NORM, 0);
         else if (current_player->watertype & CONTENTS_WATER)
-            gi.sound(current_player, CHAN_BODY, gi.soundindex("player/watr_in.wav"), 1, ATTN_NORM, 0);
+            gi_sound(current_player, CHAN_BODY, gi_soundindex("player/watr_in.wav"), 1, ATTN_NORM, 0);
         current_player->flags |= FL_INWATER;
 
         // clear damage_debounce, so the pain sound will play immediately
@@ -585,7 +585,7 @@ void P_WorldEffects(void)
     //
     if (old_waterlevel && ! waterlevel) {
         PlayerNoise(current_player, current_player->s.origin, PNOISE_SELF);
-        gi.sound(current_player, CHAN_BODY, gi.soundindex("player/watr_out.wav"), 1, ATTN_NORM, 0);
+        gi_sound(current_player, CHAN_BODY, gi_soundindex("player/watr_out.wav"), 1, ATTN_NORM, 0);
         current_player->flags &= ~FL_INWATER;
     }
 
@@ -593,7 +593,7 @@ void P_WorldEffects(void)
     // check for head just going under water
     //
     if (old_waterlevel != 3 && waterlevel == 3) {
-        gi.sound(current_player, CHAN_BODY, gi.soundindex("player/watr_un.wav"), 1, ATTN_NORM, 0);
+        gi_sound(current_player, CHAN_BODY, gi_soundindex("player/watr_un.wav"), 1, ATTN_NORM, 0);
     }
 
     //
@@ -602,11 +602,11 @@ void P_WorldEffects(void)
     if (old_waterlevel == 3 && waterlevel != 3) {
         if (current_player->air_finished_framenum < level.framenum) {
             // gasp for air
-            gi.sound(current_player, CHAN_VOICE, gi.soundindex("player/gasp1.wav"), 1, ATTN_NORM, 0);
+            gi_sound(current_player, CHAN_VOICE, gi_soundindex("player/gasp1.wav"), 1, ATTN_NORM, 0);
             PlayerNoise(current_player, current_player->s.origin, PNOISE_SELF);
         } else  if (current_player->air_finished_framenum < level.framenum + 11 * BASE_FRAMERATE) {
             // just break surface
-            gi.sound(current_player, CHAN_VOICE, gi.soundindex("player/gasp2.wav"), 1, ATTN_NORM, 0);
+            gi_sound(current_player, CHAN_VOICE, gi_soundindex("player/gasp2.wav"), 1, ATTN_NORM, 0);
         }
     }
 
@@ -620,9 +620,9 @@ void P_WorldEffects(void)
 
             if (((int)(current_client->breather_framenum - level.framenum) % 25) == 0) {
                 if (!current_client->breather_sound)
-                    gi.sound(current_player, CHAN_AUTO, gi.soundindex("player/u_breath1.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(current_player, CHAN_AUTO, gi_soundindex("player/u_breath1.wav"), 1, ATTN_NORM, 0);
                 else
-                    gi.sound(current_player, CHAN_AUTO, gi.soundindex("player/u_breath2.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(current_player, CHAN_AUTO, gi_soundindex("player/u_breath2.wav"), 1, ATTN_NORM, 0);
                 current_client->breather_sound ^= 1;
                 PlayerNoise(current_player, current_player->s.origin, PNOISE_SELF);
                 //FIXME: release a bubble?
@@ -643,11 +643,11 @@ void P_WorldEffects(void)
 
                 // play a gurp sound instead of a normal pain sound
                 if (current_player->health <= current_player->dmg)
-                    gi.sound(current_player, CHAN_VOICE, gi.soundindex("player/drown1.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(current_player, CHAN_VOICE, gi_soundindex("player/drown1.wav"), 1, ATTN_NORM, 0);
                 else if (Q_rand() & 1)
-                    gi.sound(current_player, CHAN_VOICE, gi.soundindex("*gurp1.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(current_player, CHAN_VOICE, gi_soundindex("*gurp1.wav"), 1, ATTN_NORM, 0);
                 else
-                    gi.sound(current_player, CHAN_VOICE, gi.soundindex("*gurp2.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(current_player, CHAN_VOICE, gi_soundindex("*gurp2.wav"), 1, ATTN_NORM, 0);
 
                 current_player->pain_debounce_framenum = level.framenum;
 
@@ -668,9 +668,9 @@ void P_WorldEffects(void)
                 && current_player->pain_debounce_framenum <= level.framenum
                 && current_client->invincible_framenum < level.framenum) {
                 if (Q_rand() & 1)
-                    gi.sound(current_player, CHAN_VOICE, gi.soundindex("player/burn1.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(current_player, CHAN_VOICE, gi_soundindex("player/burn1.wav"), 1, ATTN_NORM, 0);
                 else
-                    gi.sound(current_player, CHAN_VOICE, gi.soundindex("player/burn2.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(current_player, CHAN_VOICE, gi_soundindex("player/burn2.wav"), 1, ATTN_NORM, 0);
                 current_player->pain_debounce_framenum = level.framenum + 1 * BASE_FRAMERATE;
             }
 
@@ -769,7 +769,7 @@ void G_SetClientSound(edict_t *ent)
     // help beep (no more than three times)
     if (ent->client->pers.helpchanged && ent->client->pers.helpchanged <= 3 && !(level.framenum & 63)) {
         ent->client->pers.helpchanged++;
-        gi.sound(ent, CHAN_VOICE, gi.soundindex("misc/pc_up.wav"), 1, ATTN_STATIC, 0);
+        gi_sound(ent, CHAN_VOICE, gi_soundindex("misc/pc_up.wav"), 1, ATTN_STATIC, 0);
     }
 
 
@@ -781,9 +781,9 @@ void G_SetClientSound(edict_t *ent)
     if (ent->waterlevel && (ent->watertype & (CONTENTS_LAVA | CONTENTS_SLIME)))
         ent->s.sound = snd_fry;
     else if (strcmp(weap, "weapon_railgun") == 0)
-        ent->s.sound = gi.soundindex("weapons/rg_hum.wav");
+        ent->s.sound = gi_soundindex("weapons/rg_hum.wav");
     else if (strcmp(weap, "weapon_bfg") == 0)
-        ent->s.sound = gi.soundindex("weapons/bfg_hum.wav");
+        ent->s.sound = gi_soundindex("weapons/bfg_hum.wav");
     else if (ent->client->weapon_sound)
         ent->s.sound = ent->client->weapon_sound;
     else
@@ -1006,6 +1006,6 @@ void ClientEndServerFrame(edict_t *ent)
     // if the scoreboard is up, update it
     if (ent->client->showscores && !(level.framenum & 31)) {
         DeathmatchScoreboardMessage(ent, ent->enemy);
-        gi.unicast(ent, false);
+        gi_unicast(ent, false);
     }
 }

--- a/src/baseq2/p_weapon.c
+++ b/src/baseq2/p_weapon.c
@@ -103,7 +103,7 @@ void PlayerNoise(edict_t *who, vec3_t where, int type)
     VectorSubtract(where, noise->maxs, noise->absmin);
     VectorAdd(where, noise->maxs, noise->absmax);
     noise->last_sound_framenum = level.framenum;
-    gi.linkentity(noise);
+    gi_linkentity(noise);
 }
 
 
@@ -197,7 +197,7 @@ void ChangeWeapon(edict_t *ent)
 
     ent->client->weaponstate = WEAPON_ACTIVATING;
     ent->client->ps.gunframe = 0;
-    ent->client->ps.gunindex = gi.modelindex(ent->client->pers.weapon->view_model);
+    ent->client->ps.gunindex = gi_modelindex(ent->client->pers.weapon->view_model);
 
     ent->client->anim_priority = ANIM_PAIN;
     if (ent->client->ps.pmove.pm_flags & PMF_DUCKED) {
@@ -298,12 +298,12 @@ void Use_Weapon(edict_t *ent, gitem_t *item)
         ammo_index = ITEM_INDEX(ammo_item);
 
         if (!ent->client->pers.inventory[ammo_index]) {
-            gi.cprintf(ent, PRINT_HIGH, "No %s for %s.\n", ammo_item->pickup_name, item->pickup_name);
+            gi_cprintf(ent, PRINT_HIGH, "No %s for %s.\n", ammo_item->pickup_name, item->pickup_name);
             return;
         }
 
         if (ent->client->pers.inventory[ammo_index] < item->quantity) {
-            gi.cprintf(ent, PRINT_HIGH, "Not enough %s for %s.\n", ammo_item->pickup_name, item->pickup_name);
+            gi_cprintf(ent, PRINT_HIGH, "Not enough %s for %s.\n", ammo_item->pickup_name, item->pickup_name);
             return;
         }
     }
@@ -329,7 +329,7 @@ void Drop_Weapon(edict_t *ent, gitem_t *item)
     index = ITEM_INDEX(item);
     // see if we're already using it
     if (((item == ent->client->pers.weapon) || (item == ent->client->newweapon)) && (ent->client->pers.inventory[index] == 1)) {
-        gi.cprintf(ent, PRINT_HIGH, "Can't drop current weapon\n");
+        gi_cprintf(ent, PRINT_HIGH, "Can't drop current weapon\n");
         return;
     }
 
@@ -425,7 +425,7 @@ void Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, 
                 }
             } else {
                 if (level.framenum >= ent->pain_debounce_framenum) {
-                    gi.sound(ent, CHAN_VOICE, gi.soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(ent, CHAN_VOICE, gi_soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
                     ent->pain_debounce_framenum = level.framenum + 1 * BASE_FRAMERATE;
                 }
                 NoAmmoWeaponChange(ent);
@@ -454,7 +454,7 @@ void Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, 
         for (n = 0; fire_frames[n]; n++) {
             if (ent->client->ps.gunframe == fire_frames[n]) {
                 if (ent->client->quad_framenum > level.framenum)
-                    gi.sound(ent, CHAN_ITEM, gi.soundindex("items/damage3.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(ent, CHAN_ITEM, gi_soundindex("items/damage3.wav"), 1, ATTN_NORM, 0);
 
                 fire(ent);
                 break;
@@ -549,7 +549,7 @@ void Weapon_Grenade(edict_t *ent)
                 ent->client->grenade_framenum = 0;
             } else {
                 if (level.framenum >= ent->pain_debounce_framenum) {
-                    gi.sound(ent, CHAN_VOICE, gi.soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
+                    gi_sound(ent, CHAN_VOICE, gi_soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
                     ent->pain_debounce_framenum = level.framenum + 1 * BASE_FRAMERATE;
                 }
                 NoAmmoWeaponChange(ent);
@@ -569,12 +569,12 @@ void Weapon_Grenade(edict_t *ent)
 
     if (ent->client->weaponstate == WEAPON_FIRING) {
         if (ent->client->ps.gunframe == 5)
-            gi.sound(ent, CHAN_WEAPON, gi.soundindex("weapons/hgrena1b.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_WEAPON, gi_soundindex("weapons/hgrena1b.wav"), 1, ATTN_NORM, 0);
 
         if (ent->client->ps.gunframe == 11) {
             if (!ent->client->grenade_framenum) {
                 ent->client->grenade_framenum = level.framenum + (GRENADE_TIMER + 0.2f) * BASE_FRAMERATE;
-                ent->client->weapon_sound = gi.soundindex("weapons/hgrenc1b.wav");
+                ent->client->weapon_sound = gi_soundindex("weapons/hgrenc1b.wav");
             }
 
             // they waited too long, detonate it in their hand
@@ -643,10 +643,10 @@ void weapon_grenadelauncher_fire(edict_t *ent)
 
     fire_grenade(ent, start, forward, damage, 600, 2.5f, radius);
 
-    gi.WriteByte(svc_muzzleflash);
-    gi.WriteShort(ent - g_edicts);
-    gi.WriteByte(MZ_GRENADE | is_silenced);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash);
+    gi_WriteShort(ent - g_edicts);
+    gi_WriteByte(MZ_GRENADE | is_silenced);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 
     ent->client->ps.gunframe++;
 
@@ -698,10 +698,10 @@ void Weapon_RocketLauncher_Fire(edict_t *ent)
     fire_rocket(ent, start, forward, damage, 650, damage_radius, radius_damage);
 
     // send muzzle flash
-    gi.WriteByte(svc_muzzleflash);
-    gi.WriteShort(ent - g_edicts);
-    gi.WriteByte(MZ_ROCKET | is_silenced);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash);
+    gi_WriteShort(ent - g_edicts);
+    gi_WriteByte(MZ_ROCKET | is_silenced);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 
     ent->client->ps.gunframe++;
 
@@ -747,13 +747,13 @@ void Blaster_Fire(edict_t *ent, vec3_t g_offset, int damage, bool hyper, int eff
     fire_blaster(ent, start, forward, damage, 1000, effect, hyper);
 
     // send muzzle flash
-    gi.WriteByte(svc_muzzleflash);
-    gi.WriteShort(ent - g_edicts);
+    gi_WriteByte(svc_muzzleflash);
+    gi_WriteShort(ent - g_edicts);
     if (hyper)
-        gi.WriteByte(MZ_HYPERBLASTER | is_silenced);
+        gi_WriteByte(MZ_HYPERBLASTER | is_silenced);
     else
-        gi.WriteByte(MZ_BLASTER | is_silenced);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+        gi_WriteByte(MZ_BLASTER | is_silenced);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 
     PlayerNoise(ent, start, PNOISE_WEAPON);
 }
@@ -787,14 +787,14 @@ void Weapon_HyperBlaster_Fire(edict_t *ent)
     int     effect;
     int     damage;
 
-    ent->client->weapon_sound = gi.soundindex("weapons/hyprbl1a.wav");
+    ent->client->weapon_sound = gi_soundindex("weapons/hyprbl1a.wav");
 
     if (!(ent->client->buttons & BUTTON_ATTACK)) {
         ent->client->ps.gunframe++;
     } else {
         if (! ent->client->pers.inventory[ent->client->ammo_index]) {
             if (level.framenum >= ent->pain_debounce_framenum) {
-                gi.sound(ent, CHAN_VOICE, gi.soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
+                gi_sound(ent, CHAN_VOICE, gi_soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
                 ent->pain_debounce_framenum = level.framenum + 1 * BASE_FRAMERATE;
             }
             NoAmmoWeaponChange(ent);
@@ -832,7 +832,7 @@ void Weapon_HyperBlaster_Fire(edict_t *ent)
     }
 
     if (ent->client->ps.gunframe == 12) {
-        gi.sound(ent, CHAN_AUTO, gi.soundindex("weapons/hyprbd1a.wav"), 1, ATTN_NORM, 0);
+        gi_sound(ent, CHAN_AUTO, gi_soundindex("weapons/hyprbd1a.wav"), 1, ATTN_NORM, 0);
         ent->client->weapon_sound = 0;
     }
 
@@ -878,7 +878,7 @@ void Machinegun_Fire(edict_t *ent)
     if (ent->client->pers.inventory[ent->client->ammo_index] < 1) {
         ent->client->ps.gunframe = 6;
         if (level.framenum >= ent->pain_debounce_framenum) {
-            gi.sound(ent, CHAN_VOICE, gi.soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_VOICE, gi_soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
             ent->pain_debounce_framenum = level.framenum + 1 * BASE_FRAMERATE;
         }
         NoAmmoWeaponChange(ent);
@@ -911,10 +911,10 @@ void Machinegun_Fire(edict_t *ent)
     P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
     fire_bullet(ent, start, forward, damage, kick, DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD, MOD_MACHINEGUN);
 
-    gi.WriteByte(svc_muzzleflash);
-    gi.WriteShort(ent - g_edicts);
-    gi.WriteByte(MZ_MACHINEGUN | is_silenced);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash);
+    gi_WriteShort(ent - g_edicts);
+    gi_WriteByte(MZ_MACHINEGUN | is_silenced);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 
     PlayerNoise(ent, start, PNOISE_WEAPON);
 
@@ -956,7 +956,7 @@ void Chaingun_Fire(edict_t *ent)
         damage = 8;
 
     if (ent->client->ps.gunframe == 5)
-        gi.sound(ent, CHAN_AUTO, gi.soundindex("weapons/chngnu1a.wav"), 1, ATTN_IDLE, 0);
+        gi_sound(ent, CHAN_AUTO, gi_soundindex("weapons/chngnu1a.wav"), 1, ATTN_IDLE, 0);
 
     if ((ent->client->ps.gunframe == 14) && !(ent->client->buttons & BUTTON_ATTACK)) {
         ent->client->ps.gunframe = 32;
@@ -971,9 +971,9 @@ void Chaingun_Fire(edict_t *ent)
 
     if (ent->client->ps.gunframe == 22) {
         ent->client->weapon_sound = 0;
-        gi.sound(ent, CHAN_AUTO, gi.soundindex("weapons/chngnd1a.wav"), 1, ATTN_IDLE, 0);
+        gi_sound(ent, CHAN_AUTO, gi_soundindex("weapons/chngnd1a.wav"), 1, ATTN_IDLE, 0);
     } else {
-        ent->client->weapon_sound = gi.soundindex("weapons/chngnl1a.wav");
+        ent->client->weapon_sound = gi_soundindex("weapons/chngnl1a.wav");
     }
 
     ent->client->anim_priority = ANIM_ATTACK;
@@ -1000,7 +1000,7 @@ void Chaingun_Fire(edict_t *ent)
 
     if (!shots) {
         if (level.framenum >= ent->pain_debounce_framenum) {
-            gi.sound(ent, CHAN_VOICE, gi.soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
+            gi_sound(ent, CHAN_VOICE, gi_soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
             ent->pain_debounce_framenum = level.framenum + 1 * BASE_FRAMERATE;
         }
         NoAmmoWeaponChange(ent);
@@ -1029,10 +1029,10 @@ void Chaingun_Fire(edict_t *ent)
     }
 
     // send muzzle flash
-    gi.WriteByte(svc_muzzleflash);
-    gi.WriteShort(ent - g_edicts);
-    gi.WriteByte((MZ_CHAINGUN1 + shots - 1) | is_silenced);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash);
+    gi_WriteShort(ent - g_edicts);
+    gi_WriteByte((MZ_CHAINGUN1 + shots - 1) | is_silenced);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 
     PlayerNoise(ent, start, PNOISE_WEAPON);
 
@@ -1090,10 +1090,10 @@ void weapon_shotgun_fire(edict_t *ent)
         fire_shotgun(ent, start, forward, damage, kick, 500, 500, DEFAULT_SHOTGUN_COUNT, MOD_SHOTGUN);
 
     // send muzzle flash
-    gi.WriteByte(svc_muzzleflash);
-    gi.WriteShort(ent - g_edicts);
-    gi.WriteByte(MZ_SHOTGUN | is_silenced);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash);
+    gi_WriteShort(ent - g_edicts);
+    gi_WriteByte(MZ_SHOTGUN | is_silenced);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 
     ent->client->ps.gunframe++;
     PlayerNoise(ent, start, PNOISE_WEAPON);
@@ -1143,10 +1143,10 @@ void weapon_supershotgun_fire(edict_t *ent)
     fire_shotgun(ent, start, forward, damage, kick, DEFAULT_SHOTGUN_HSPREAD, DEFAULT_SHOTGUN_VSPREAD, DEFAULT_SSHOTGUN_COUNT / 2, MOD_SSHOTGUN);
 
     // send muzzle flash
-    gi.WriteByte(svc_muzzleflash);
-    gi.WriteShort(ent - g_edicts);
-    gi.WriteByte(MZ_SSHOTGUN | is_silenced);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash);
+    gi_WriteShort(ent - g_edicts);
+    gi_WriteByte(MZ_SSHOTGUN | is_silenced);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 
     ent->client->ps.gunframe++;
     PlayerNoise(ent, start, PNOISE_WEAPON);
@@ -1205,10 +1205,10 @@ void weapon_railgun_fire(edict_t *ent)
     fire_rail(ent, start, forward, damage, kick);
 
     // send muzzle flash
-    gi.WriteByte(svc_muzzleflash);
-    gi.WriteShort(ent - g_edicts);
-    gi.WriteByte(MZ_RAILGUN | is_silenced);
-    gi.multicast(ent->s.origin, MULTICAST_PVS);
+    gi_WriteByte(svc_muzzleflash);
+    gi_WriteShort(ent - g_edicts);
+    gi_WriteByte(MZ_RAILGUN | is_silenced);
+    gi_multicast(ent->s.origin, MULTICAST_PVS);
 
     ent->client->ps.gunframe++;
     PlayerNoise(ent, start, PNOISE_WEAPON);
@@ -1249,10 +1249,10 @@ void weapon_bfg_fire(edict_t *ent)
 
     if (ent->client->ps.gunframe == 9) {
         // send muzzle flash
-        gi.WriteByte(svc_muzzleflash);
-        gi.WriteShort(ent - g_edicts);
-        gi.WriteByte(MZ_BFG | is_silenced);
-        gi.multicast(ent->s.origin, MULTICAST_PVS);
+        gi_WriteByte(svc_muzzleflash);
+        gi_WriteShort(ent - g_edicts);
+        gi_WriteByte(MZ_BFG | is_silenced);
+        gi_multicast(ent->s.origin, MULTICAST_PVS);
 
         ent->client->ps.gunframe++;
 

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -69,3 +69,11 @@ const char *Q_ErrorString(int error)
 
     return error_table[e >= num_errors ? 0 : e];
 }
+
+#ifdef _MSC_VER
+int Q_ErrorNumber(void)
+{
+    int e = errno;
+    return Q_ERR(e);
+}
+#endif

--- a/src/common/zone.c
+++ b/src/common/zone.c
@@ -63,6 +63,9 @@ static const char   z_tagnames[TAG_MAX][8] = {
     "mvd",
     "sound",
     "cmodel"
+#if USE_WASM
+    , "wasm"
+#endif
 };
 
 static inline void Z_CountFree(zhead_t *z)

--- a/src/refresh/main.c
+++ b/src/refresh/main.c
@@ -697,28 +697,28 @@ static void gl_novis_changed(cvar_t *self)
 static void GL_Register(void)
 {
     // regular variables
-    gl_partscale = Cvar_Get("gl_partscale", "2", 0);
-    gl_partstyle = Cvar_Get("gl_partstyle", "0", 0);
-    gl_celshading = Cvar_Get("gl_celshading", "0", 0);
-    gl_dotshading = Cvar_Get("gl_dotshading", "1", 0);
+    gl_partscale = Cvar_Get("gl_partscale", "2", CVAR_ARCHIVE);
+    gl_partstyle = Cvar_Get("gl_partstyle", "0", CVAR_ARCHIVE);
+    gl_celshading = Cvar_Get("gl_celshading", "0", CVAR_ARCHIVE);
+    gl_dotshading = Cvar_Get("gl_dotshading", "1", CVAR_ARCHIVE);
     gl_shadows = Cvar_Get("gl_shadows", "0", CVAR_ARCHIVE);
     gl_modulate = Cvar_Get("gl_modulate", "1", CVAR_ARCHIVE);
     gl_modulate->changed = gl_modulate_changed;
-    gl_modulate_world = Cvar_Get("gl_modulate_world", "1", 0);
+    gl_modulate_world = Cvar_Get("gl_modulate_world", "1", CVAR_ARCHIVE);
     gl_modulate_world->changed = gl_lightmap_changed;
-    gl_coloredlightmaps = Cvar_Get("gl_coloredlightmaps", "1", 0);
+    gl_coloredlightmaps = Cvar_Get("gl_coloredlightmaps", "1", CVAR_ARCHIVE);
     gl_coloredlightmaps->changed = gl_lightmap_changed;
-    gl_brightness = Cvar_Get("gl_brightness", "0", 0);
+    gl_brightness = Cvar_Get("gl_brightness", "0", CVAR_ARCHIVE);
     gl_brightness->changed = gl_lightmap_changed;
-    gl_dynamic = Cvar_Get("gl_dynamic", "2", 0);
+    gl_dynamic = Cvar_Get("gl_dynamic", "2", CVAR_ARCHIVE);
     gl_dynamic->changed = gl_lightmap_changed;
 #if USE_DLIGHTS
-    gl_dlight_falloff = Cvar_Get("gl_dlight_falloff", "1", 0);
+    gl_dlight_falloff = Cvar_Get("gl_dlight_falloff", "1", CVAR_ARCHIVE);
 #endif
-    gl_modulate_entities = Cvar_Get("gl_modulate_entities", "1", 0);
+    gl_modulate_entities = Cvar_Get("gl_modulate_entities", "1", CVAR_ARCHIVE);
     gl_modulate_entities->changed = gl_modulate_entities_changed;
-    gl_doublelight_entities = Cvar_Get("gl_doublelight_entities", "1", 0);
-    gl_fontshadow = Cvar_Get("gl_fontshadow", "0", 0);
+    gl_doublelight_entities = Cvar_Get("gl_doublelight_entities", "1", CVAR_ARCHIVE);
+    gl_fontshadow = Cvar_Get("gl_fontshadow", "0", CVAR_ARCHIVE);
     gl_shaders = Cvar_Get("gl_shaders", (gl_config.caps & QGL_CAP_SHADER) ? "1" : "0", CVAR_REFRESH);
 
     // development variables
@@ -747,9 +747,9 @@ static void GL_Register(void)
     gl_lightmap = Cvar_Get("gl_lightmap", "0", CVAR_CHEAT);
     gl_fullbright = Cvar_Get("r_fullbright", "0", CVAR_CHEAT);
     gl_fullbright->changed = gl_lightmap_changed;
-    gl_vertexlight = Cvar_Get("gl_vertexlight", "0", 0);
+    gl_vertexlight = Cvar_Get("gl_vertexlight", "0", CVAR_ARCHIVE);
     gl_vertexlight->changed = gl_lightmap_changed;
-    gl_polyblend = Cvar_Get("gl_polyblend", "1", 0);
+    gl_polyblend = Cvar_Get("gl_polyblend", "1", CVAR_ARCHIVE);
     gl_showerrors = Cvar_Get("gl_showerrors", "1", 0);
 
     gl_lightmap_changed(NULL);

--- a/src/refresh/qgl.h
+++ b/src/refresh/qgl.h
@@ -22,6 +22,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if USE_SDL
 #include <SDL_opengl.h>
 #else
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
 #include <GL/gl.h>
 #include <GL/glext.h>
 #endif

--- a/src/server/game.c
+++ b/src/server/game.c
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 game_export_t    *ge;
 
-static void PF_configstring(int index, const char *val);
+void PF_configstring(int index, const char *val);
 
 /*
 ================
@@ -56,17 +56,17 @@ static int PF_FindIndex(const char *name, int start, int max, const char *func)
     return i;
 }
 
-static int PF_ModelIndex(const char *name)
+int PF_ModelIndex(const char *name)
 {
     return PF_FindIndex(name, CS_MODELS, MAX_MODELS, __func__);
 }
 
-static int PF_SoundIndex(const char *name)
+int PF_SoundIndex(const char *name)
 {
     return PF_FindIndex(name, CS_SOUNDS, MAX_SOUNDS, __func__);
 }
 
-static int PF_ImageIndex(const char *name)
+int PF_ImageIndex(const char *name)
 {
     return PF_FindIndex(name, CS_IMAGES, MAX_IMAGES, __func__);
 }
@@ -79,7 +79,7 @@ Sends the contents of the mutlicast buffer to a single client.
 Archived in MVD stream.
 ===============
 */
-static void PF_Unicast(edict_t *ent, qboolean reliable)
+void PF_Unicast(edict_t *ent, qboolean reliable)
 {
     client_t    *client;
     int         cmd, flags, clientNum;
@@ -138,7 +138,7 @@ Sends text to all active clients.
 Archived in MVD stream.
 =================
 */
-static void PF_bprintf(int level, const char *fmt, ...)
+void PF_bprintf(int level, const char *fmt, ...)
 {
     va_list     argptr;
     char        string[MAX_STRING_CHARS];
@@ -207,7 +207,7 @@ Print to a single client if the level passes.
 Archived in MVD stream.
 ===============
 */
-static void PF_cprintf(edict_t *ent, int level, const char *fmt, ...)
+void PF_cprintf(edict_t *ent, int level, const char *fmt, ...)
 {
     char        msg[MAX_STRING_CHARS];
     va_list     argptr;
@@ -261,7 +261,7 @@ Centerprint to a single client.
 Archived in MVD stream.
 ===============
 */
-static void PF_centerprintf(edict_t *ent, const char *fmt, ...)
+void PF_centerprintf(edict_t *ent, const char *fmt, ...)
 {
     char        msg[MAX_STRING_CHARS];
     va_list     argptr;
@@ -319,7 +319,7 @@ PF_setmodel
 Also sets mins and maxs for inline bmodels
 =================
 */
-static void PF_setmodel(edict_t *ent, const char *name)
+void PF_setmodel(edict_t *ent, const char *name)
 {
     mmodel_t    *mod;
 
@@ -345,7 +345,7 @@ If game is actively running, broadcasts configstring change.
 Archived in MVD stream.
 ===============
 */
-static void PF_configstring(int index, const char *val)
+void PF_configstring(int index, const char *val)
 {
     size_t len, maxlen;
     client_t *client;
@@ -411,7 +411,7 @@ static void PF_configstring(int index, const char *val)
     SZ_Clear(&msg_write);
 }
 
-static void PF_WriteFloat(float f)
+void PF_WriteFloat(float f)
 {
     Com_Error(ERR_DROP, "PF_WriteFloat not implemented");
 }
@@ -446,7 +446,7 @@ PF_inPVS
 Also checks portalareas so that doors block sight
 =================
 */
-static qboolean PF_inPVS(vec3_t p1, vec3_t p2)
+qboolean PF_inPVS(vec3_t p1, vec3_t p2)
 {
     return PF_inVIS(p1, p2, DVIS_PVS);
 }
@@ -458,7 +458,7 @@ PF_inPHS
 Also checks portalareas so that doors block sound
 =================
 */
-static qboolean PF_inPHS(vec3_t p1, vec3_t p2)
+qboolean PF_inPHS(vec3_t p1, vec3_t p2)
 {
     return PF_inVIS(p1, p2, DVIS_PHS);
 }
@@ -489,9 +489,9 @@ If origin is NULL, the origin is determined from the entity origin
 or the midpoint of the entity box for bmodels.
 ==================
 */
-static void SV_StartSound(vec3_t origin, edict_t *edict, int channel,
-                          int soundindex, float volume,
-                          float attenuation, float timeofs)
+void SV_StartSound(vec3_t origin, edict_t *edict, int channel,
+                   int soundindex, float volume,
+                   float attenuation, float timeofs)
 {
     int         i, ent, flags, sendchan;
     vec3_t      origin_v;
@@ -648,9 +648,9 @@ static void SV_StartSound(vec3_t origin, edict_t *edict, int channel,
                      volume * 255, attenuation * 64, timeofs * 1000);
 }
 
-static void PF_StartSound(edict_t *entity, int channel,
-                          int soundindex, float volume,
-                          float attenuation, float timeofs)
+void PF_StartSound(edict_t *entity, int channel,
+                   int soundindex, float volume,
+                   float attenuation, float timeofs)
 {
     if (!entity)
         return;
@@ -666,7 +666,7 @@ void PF_Pmove(pmove_t *pm)
     }
 }
 
-static cvar_t *PF_cvar(const char *name, const char *value, int flags)
+cvar_t *PF_cvar(const char *name, const char *value, int flags)
 {
     if (flags & CVAR_EXTENDED_MASK) {
         Com_WPrintf("Game attemped to set extended flags on '%s', masked out.\n", name);
@@ -676,12 +676,12 @@ static cvar_t *PF_cvar(const char *name, const char *value, int flags)
     return Cvar_Get(name, value, flags | CVAR_GAME);
 }
 
-static void PF_AddCommandString(const char *string)
+void PF_AddCommandString(const char *string)
 {
     Cbuf_AddText(&cmd_buffer, string);
 }
 
-static void PF_SetAreaPortalState(int portalnum, qboolean open)
+void PF_SetAreaPortalState(int portalnum, qboolean open)
 {
     if (!sv.cm.cache) {
         Com_Error(ERR_DROP, "%s: no map loaded", __func__);
@@ -689,7 +689,7 @@ static void PF_SetAreaPortalState(int portalnum, qboolean open)
     CM_SetAreaPortalState(&sv.cm, portalnum, open);
 }
 
-static qboolean PF_AreasConnected(int area1, int area2)
+qboolean PF_AreasConnected(int area1, int area2)
 {
     if (!sv.cm.cache) {
         Com_Error(ERR_DROP, "%s: no map loaded", __func__);
@@ -716,7 +716,7 @@ static void PF_FreeTags(unsigned tag)
     Z_FreeTags(tag + TAG_MAX);
 }
 
-static void PF_DebugGraph(float value, int color)
+void PF_DebugGraph(float value, int color)
 {
 }
 
@@ -792,6 +792,11 @@ void SV_InitGameProgs(void)
 
     // unload anything we have now
     SV_ShutdownGameProgs();
+
+#if USE_WASM
+    if (SV_InitGameWasmProgs())
+        return;
+#endif
 
     // for debugging or `proxy' mods
     if (sys_forcegamelib->string[0])
@@ -884,12 +889,12 @@ void SV_InitGameProgs(void)
     ge->Init();
 
     // sanitize edict_size
-    if (ge->edict_size < sizeof(edict_t) || ge->edict_size > (unsigned)INT_MAX / MAX_EDICTS) {
+    if (ge->pool.edict_size < sizeof(edict_t) || ge->pool.edict_size > (unsigned)INT_MAX / MAX_EDICTS) {
         Com_Error(ERR_DROP, "Game library returned bad size of edict_t");
     }
 
     // sanitize max_edicts
-    if (ge->max_edicts <= sv_maxclients->integer || ge->max_edicts > MAX_EDICTS) {
+    if (ge->pool.max_edicts <= sv_maxclients->integer || ge->pool.max_edicts > MAX_EDICTS) {
         Com_Error(ERR_DROP, "Game library returned bad number of max_edicts");
     }
 }

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -1103,7 +1103,7 @@ static void SVC_DirectConnect(void)
     newcl->gamedir = fs_game->string;
     newcl->mapname = sv.name;
     newcl->configstrings = (char *)sv.configstrings;
-    newcl->pool = (edict_pool_t *)&ge->edicts;
+    newcl->pool = &ge->pool;
     newcl->cm = &sv.cm;
     newcl->spawncount = sv.spawncount;
     newcl->maxclients = sv_maxclients->integer;
@@ -1710,7 +1710,7 @@ static void SV_PrepWorldFrame(void)
     if (!SV_FRAMESYNC)
         return;
 
-    for (i = 1; i < ge->num_edicts; i++) {
+    for (i = 1; i < ge->pool.num_edicts; i++) {
         ent = EDICT_NUM(i);
 
         // events only last for a single keyframe

--- a/src/server/mvd.c
+++ b/src/server/mvd.c
@@ -578,7 +578,7 @@ static void build_gamestate(void)
     }
 
     // set base entity states
-    for (i = 1; i < ge->num_edicts; i++) {
+    for (i = 1; i < ge->pool.num_edicts; i++) {
         ent = EDICT_NUM(i);
 
         if (!entity_is_active(ent)) {
@@ -664,7 +664,7 @@ static void emit_gamestate(void)
     MSG_WriteByte(CLIENTNUM_NONE);
 
     // send entity states
-    for (i = 1, es = mvd.entities + 1; i < ge->num_edicts; i++, es++) {
+    for (i = 1, es = mvd.entities + 1; i < ge->pool.num_edicts; i++, es++) {
         flags = MSG_ES_UMASK;
         if ((j = es->number) != 0) {
             if (i <= sv_maxclients->integer) {
@@ -768,7 +768,7 @@ static void emit_frame(void)
     MSG_WriteByte(CLIENTNUM_NONE);      // end of packetplayers
 
     // send entity states
-    for (i = 1; i < ge->num_edicts; i++) {
+    for (i = 1; i < ge->pool.num_edicts; i++) {
         oldes = &mvd.entities[i];
         ent = EDICT_NUM(i);
 

--- a/src/server/mvd/game.c
+++ b/src/server/mvd/game.c
@@ -1739,10 +1739,10 @@ static void MVD_GameInit(void)
         edicts[i + 1].client = (gclient_t *)&mvd_clients[i];
     }
 
-    mvd_ge.edicts = edicts;
-    mvd_ge.edict_size = sizeof(edict_t);
-    mvd_ge.num_edicts = sv_maxclients->integer + 1;
-    mvd_ge.max_edicts = sv_maxclients->integer + 1;
+    mvd_ge.pool.edicts = edicts;
+    mvd_ge.pool.edict_size = sizeof(edict_t);
+    mvd_ge.pool.num_edicts = sv_maxclients->integer + 1;
+    mvd_ge.pool.max_edicts = sv_maxclients->integer + 1;
 
     Q_snprintf(buffer, sizeof(buffer),
                "maps/%s.bsp", mvd_default_map->string);
@@ -1795,10 +1795,10 @@ static void MVD_GameShutdown(void)
 
     MVD_Shutdown();
 
-    mvd_ge.edicts = NULL;
-    mvd_ge.edict_size = 0;
-    mvd_ge.num_edicts = 0;
-    mvd_ge.max_edicts = 0;
+    mvd_ge.pool.edicts = NULL;
+    mvd_ge.pool.edict_size = 0;
+    mvd_ge.pool.num_edicts = 0;
+    mvd_ge.pool.max_edicts = 0;
 
     Cvar_Set("g_features", "0");
 }

--- a/src/server/mvd/parse.c
+++ b/src/server/mvd/parse.c
@@ -154,7 +154,7 @@ static void MVD_ParseMulticast(mvd_t *mvd, mvd_ops_t op, int extrabits)
     mvd_client_t    *client;
     client_t    *cl;
     byte        mask[VIS_MAX_BYTES];
-    mleaf_t     *leaf1, *leaf2;
+    mleaf_t     *leaf1 = NULL, *leaf2;
     vec3_t      org;
     bool        reliable = false;
     byte        *data;
@@ -168,7 +168,6 @@ static void MVD_ParseMulticast(mvd_t *mvd, mvd_ops_t op, int extrabits)
         reliable = true;
         // intentional fallthrough
     case mvd_multicast_all:
-        leaf1 = NULL;
         break;
     case mvd_multicast_phs_r:
         reliable = true;
@@ -176,7 +175,6 @@ static void MVD_ParseMulticast(mvd_t *mvd, mvd_ops_t op, int extrabits)
     case mvd_multicast_phs:
         leafnum = MSG_ReadWord();
         if (mvd->demoseeking) {
-            leaf1 = NULL;
             break;
         }
         leaf1 = CM_LeafNum(&mvd->cm, leafnum);
@@ -188,7 +186,6 @@ static void MVD_ParseMulticast(mvd_t *mvd, mvd_ops_t op, int extrabits)
     case mvd_multicast_pvs:
         leafnum = MSG_ReadWord();
         if (mvd->demoseeking) {
-            leaf1 = NULL;
             break;
         }
         leaf1 = CM_LeafNum(&mvd->cm, leafnum);

--- a/src/server/send.c
+++ b/src/server/send.c
@@ -256,7 +256,7 @@ void SV_Multicast(vec3_t origin, multicast_t to)
 {
     client_t    *client;
     byte        mask[VIS_MAX_BYTES];
-    mleaf_t     *leaf1, *leaf2;
+    mleaf_t     *leaf1 = NULL, *leaf2;
     int         leafnum q_unused;
     int         flags;
 
@@ -271,7 +271,6 @@ void SV_Multicast(vec3_t origin, multicast_t to)
         flags |= MSG_RELIABLE;
         // intentional fallthrough
     case MULTICAST_ALL:
-        leaf1 = NULL;
         leafnum = 0;
         break;
     case MULTICAST_PHS_R:

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -170,8 +170,8 @@ typedef struct {
 
 #define EDICT_POOL(c, n) ((edict_t *)((byte *)(c)->pool->edicts + (c)->pool->edict_size*(n)))
 
-#define EDICT_NUM(n) ((edict_t *)((byte *)ge->edicts + ge->edict_size*(n)))
-#define NUM_FOR_EDICT(e) ((int)(((byte *)(e) - (byte *)ge->edicts) / ge->edict_size))
+#define EDICT_NUM(n) ((edict_t *)((byte *)ge->pool.edicts + ge->pool.edict_size*(n)))
+#define NUM_FOR_EDICT(e) ((int)(((byte *)(e) - (byte *)ge->pool.edicts) / ge->pool.edict_size))
 
 #define MAX_TOTAL_ENT_LEAFS        128
 
@@ -258,13 +258,6 @@ typedef struct {
     unsigned    credit_cap;
     unsigned    cost;
 } ratelimit_t;
-
-typedef struct {
-    struct edict_s  *edicts;
-    int         edict_size;
-    int         num_edicts;     // current number, <= max_edicts
-    int         max_edicts;
-} edict_pool_t;
 
 typedef struct client_s {
     list_t          entry;
@@ -822,3 +815,7 @@ trace_t q_gameabi SV_Trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end,
 // to an open area
 
 // passedict is explicitly excluded from clipping checks (normally NULL)
+
+#ifdef USE_WASM
+bool SV_InitGameWasmProgs(void);
+#endif

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -744,6 +744,7 @@ void SV_WriteFrameToClient_Enhanced(client_t *client);
 // sv_game.c
 //
 extern    game_export_t    *ge;
+extern    game_export_87_t  *xge;
 
 void SV_InitGameProgs(void);
 void SV_ShutdownGameProgs(void);

--- a/src/server/wasm_game.c
+++ b/src/server/wasm_game.c
@@ -380,37 +380,37 @@ typedef struct {
 
 typedef struct {
     struct {
-        wasm_field_t    number;
+        game_field_t    number;
 
-        wasm_field_t    origin;
-        wasm_field_t    angles;
-        wasm_field_t    old_origin;
-        wasm_field_t    modelindex;
-        wasm_field_t    modelindex2, modelindex3, modelindex4;
-        wasm_field_t    frame;
-        wasm_field_t    skinnum;
-        wasm_field_t    effects;
-        wasm_field_t    renderfx;
-        wasm_field_t    solid;
+        game_field_t    origin;
+        game_field_t    angles;
+        game_field_t    old_origin;
+        game_field_t    modelindex;
+        game_field_t    modelindex2, modelindex3, modelindex4;
+        game_field_t    frame;
+        game_field_t    skinnum;
+        game_field_t    effects;
+        game_field_t    renderfx;
+        game_field_t    solid;
 
-        wasm_field_t    sound;
-        wasm_field_t    event;
+        game_field_t    sound;
+        game_field_t    event;
     } s;
 
-    wasm_field_t    client;
-    wasm_field_t    inuse;
-    wasm_field_t    linkcount;
+    game_field_t    client;
+    game_field_t    inuse;
+    game_field_t    linkcount;
 
-    wasm_field_t    area_prev;
+    game_field_t    area_prev;
 
-    wasm_field_t    areanum, areanum2;
+    game_field_t    areanum, areanum2;
 
-    wasm_field_t    svflags;
-    wasm_field_t    mins, maxs;
-    wasm_field_t    absmin, absmax, size;
-    wasm_field_t    solid;
-    wasm_field_t    clipmask;
-    wasm_field_t    owner;
+    game_field_t    svflags;
+    game_field_t    mins, maxs;
+    game_field_t    absmin, absmax, size;
+    game_field_t    solid;
+    game_field_t    clipmask;
+    game_field_t    owner;
 } wasm_edict_layout_t;
 
 #define WASM_FIELD(t, member, n) \
@@ -1236,15 +1236,15 @@ static bool _SV_InitGameWasm(void)
 
     // it's a valid WASM module! It might still not be a valid mod binary, though.
     // now, we find all of the linked functions.
-    uint32_t return_values[1] = { WASM_API_VERSION };
+    uint32_t return_values[1] = { GAME_API_EXTENDED_VERSION };
 
 	wasm_function_t GetGameAPI = SV_GetWASMFunction("GetGameAPI", "(i)i", true);
 
     SV_CallWASMFunction(GetGameAPI, 1, return_values);
 
-    if (return_values[0] != WASM_API_VERSION) {
+    if (return_values[0] != GAME_API_EXTENDED_VERSION) {
         Com_Printf("Wasm library is version %d, expected %d\n",
-                  return_values[0], WASM_API_VERSION);
+                  return_values[0], GAME_API_EXTENDED_VERSION);
         return false;
     }
 
@@ -1580,8 +1580,8 @@ static game_capability_t SV_QueryGameCapabilityWasm(const char *cap)
     return (game_capability_t) args[0];
 }
 
-static wasm_game_export_t wasm_game_exports = {
-    WASM_API_VERSION,
+static game_export_87_t wasm_game_exports = {
+    GAME_API_EXTENDED_VERSION,
 
     // set up our game exports wrapper
     SV_InitGameWasm,

--- a/src/server/wasm_game.c
+++ b/src/server/wasm_game.c
@@ -302,6 +302,7 @@ static void SV_ShutdownGameWasm(void)
     memset(&wasm_mem, 0, sizeof(wasm_mem));
 
     Cvar_DestroyWASMLinkage();
+    Cmd_DestroyWASMLinkage();
 
     Z_FreeTags(TAG_WASM);
 
@@ -1040,17 +1041,12 @@ static int32_t PF_wasm_argc(wasm_exec_env_t env)
 
 static uint32_t PF_wasm_argv(wasm_exec_env_t env, int32_t i)
 {
-    return 0;
-	/*if (i < 0 || i >= sizeof(wasm_buffers_t::cmds) / sizeof(*wasm_buffers_t::cmds))
-		return 0;
-
-	return WASM_BUFFERS_OFFSET(cmds[i]);*/
+    return Cmd_ArgvWASM(i);
 }
 
 static uint32_t PF_wasm_args(wasm_exec_env_t env)
 {
-    return 0;
-	//return WASM_BUFFERS_OFFSET(scmd);
+    return Cmd_RawArgsWASM();
 }
 
 static void PF_wasm_AddCommandString(wasm_exec_env_t env, const char *string)
@@ -1251,8 +1247,8 @@ static bool _SV_InitGameWasm(void)
 	wasm_ge.GetEdicts = SV_GetWASMFunction("GetEdicts", "()i", true);
 	wasm_ge.GetNumEdicts = SV_GetWASMFunction("GetNumEdicts", "()*", true);
 
-	wasm_ge.PmoveTrace = SV_GetWASMFunction("PmoveTrace", "(******)", true);
-	wasm_ge.PmovePointContents = SV_GetWASMFunction("PmovePointContents", "(**)", true);
+	wasm_ge.PmoveTrace = SV_GetWASMFunction("PmoveTrace", "(*ffffffffffff*)", true);
+	wasm_ge.PmovePointContents = SV_GetWASMFunction("PmovePointContents", "(*fff)", true);
 	wasm_ge.Init = SV_GetWASMFunction("Init", NULL, true);
 	wasm_ge.SpawnEntities = SV_GetWASMFunction("SpawnEntities", "($$$)", true);
 	wasm_ge.ClientConnect = SV_GetWASMFunction("ClientConnect", "(*$)i", true);
@@ -1267,7 +1263,6 @@ static bool _SV_InitGameWasm(void)
 	wasm_ge.ReadGame = SV_GetWASMFunction("ReadGame", "($)", true);
 	wasm_ge.WriteLevel = SV_GetWASMFunction("WriteLevel", "($)", true);
 	wasm_ge.ReadLevel = SV_GetWASMFunction("ReadLevel", "($)", true);
-
 	wasm_ge.QueryGameCapability = SV_GetWASMFunction("QueryGameCapability", "($)*", true);
     
     // from beyond this point, we mark as loaded so other subsystems can be made aware of

--- a/src/server/wasm_game.c
+++ b/src/server/wasm_game.c
@@ -378,28 +378,6 @@ typedef struct {
 	wasm_address_t	owner;
 } wasm_edict_t;
 
-/*
-
-    int     number;         // edict index
-
-    vec3_t  origin;
-    vec3_t  angles;
-    vec3_t  old_origin;     // for lerping
-    int     modelindex;
-    int     modelindex2, modelindex3, modelindex4;  // weapons, CTF flags, etc
-    int     frame;
-    int     skinnum;
-    unsigned int        effects;        // PGM - we're filling it, so it needs to be unsigned
-    int     renderfx;
-    int     solid;          // for client side prediction, 8*(bits 0-4) is x/y radius
-                            // 8*(bits 5-9) is z down distance, 8(bits10-15) is z up
-                            // gi.linkentity sets this properly
-    int     sound;          // for looping sounds, to guarantee shutoff
-    int     event;          // impulse events -- muzzle flashes, footsteps, etc
-                            // events only go out for a single frame, they
-                            // are automatically cleared each frame
-*/
-
 typedef struct {
     struct {
         wasm_field_t    number;
@@ -1645,6 +1623,12 @@ a new map. Returns false if we can't.
 */
 bool SV_InitGameWasmProgs(void)
 {
+    if (sys_nowasm->value)
+    {
+        Com_Printf("Skipping WASM due to sys_nowasm\n");
+        return false;
+    }
+
     List_Init(&tagged_memory);
 
     if (!_SV_InitGameWasm())

--- a/src/server/wasm_game.c
+++ b/src/server/wasm_game.c
@@ -1,0 +1,1665 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+// sv_game.c -- interface to the game dll
+
+#include "server.h"
+
+#include <wasm_export.h>
+
+#ifdef _MSC_VER
+#include <malloc.h>
+#endif
+
+// from game.c
+qboolean PF_inPHS(vec3_t p1, vec3_t p2);
+qboolean PF_inPVS(vec3_t p1, vec3_t p2);
+void PF_WriteFloat(float f);
+void PF_configstring(int index, const char *val);
+void PF_setmodel(edict_t *ent, const char *name);
+void PF_centerprintf(edict_t *ent, const char *fmt, ...);
+void PF_cprintf(edict_t *ent, int level, const char *fmt, ...);
+void PF_bprintf(int level, const char *fmt, ...);
+void PF_Unicast(edict_t *ent, qboolean reliable);
+int PF_ImageIndex(const char *name);
+int PF_SoundIndex(const char *name);
+int PF_ModelIndex(const char *name);
+void PF_AddCommandString(const char *string);
+void PF_SetAreaPortalState(int portalnum, qboolean open);
+qboolean PF_AreasConnected(int area1, int area2);
+void PF_DebugGraph(float value, int color);
+void PF_StartSound(edict_t *entity, int channel,
+                   int soundindex, float volume,
+                   float attenuation, float timeofs);
+void SV_StartSound(vec3_t origin, edict_t *edict, int channel,
+                   int soundindex, float volume,
+                   float attenuation, float timeofs);
+cvar_t *PF_cvar(const char *name, const char *value, int flags);
+
+typedef void *wasm_function_t;
+
+typedef struct {
+    bool    loaded; // whether we've got a valid, loaded WASM game module
+
+    // Since GetGameAPI can't return a value/pointer, otherwise the optimizer
+    // tends to optimize out max_edicts, we have these new endpoints to fetch
+    // the returned components of the game export.
+	wasm_function_t GetEdicts; // returns a pointer to where the current edicts are being held
+	wasm_function_t GetNumEdicts; // returns a pointer where the current num_edicts is being held
+    
+    wasm_function_t PmoveTrace;
+    wasm_function_t PmovePointContents;
+
+    // the init function will only be called when a game starts,
+    // not each time a level is loaded.  Persistant data for clients
+    // and the server can be allocated in init
+    wasm_function_t Init;
+    wasm_function_t Shutdown;
+
+    // each new level entered will cause a call to SpawnEntities
+    wasm_function_t SpawnEntities;
+
+    // Read/Write Game is for storing persistant cross level information
+    // about the world state and the clients.
+    // WriteGame is called every time a level is exited.
+    // ReadGame is called on a loadgame.
+    wasm_function_t WriteGame;
+    wasm_function_t ReadGame;
+
+    // ReadLevel is called after the default map information has been
+    // loaded with SpawnEntities
+    wasm_function_t WriteLevel;
+    wasm_function_t ReadLevel;
+
+    wasm_function_t ClientConnect;
+    wasm_function_t ClientBegin;
+    wasm_function_t ClientUserinfoChanged;
+    wasm_function_t ClientDisconnect;
+    wasm_function_t ClientCommand;
+    wasm_function_t ClientThink;
+
+    wasm_function_t RunFrame;
+
+    // ServerCommand will be called when an "sv <command>" command is issued on the
+    // server console.
+    // The game can issue gi.argc() / gi.argv() commands to get the rest
+    // of the parameters
+    wasm_function_t ServerCommand;
+
+    //
+    // global variables shared between game and server
+    //
+
+    // The edict array is allocated in the game dll so it
+    // can vary in size from one game to another.
+    //
+    // The size will be fixed when ge->Init() is called
+    wasm_address_t  edicts, edicts_end;
+    wasm_address_t  num_edicts;     // current number, <= max_edicts
+    uint32_t edict_size;
+
+    wasm_function_t QueryGameCapability;
+} wasm_export_t;
+
+// this contains addresses to special bits of data that
+// we will need to communicate between WASM and native.
+typedef struct {
+    // Zeroed texinfo; sizeof(csurface_t)
+    wasm_address_t nulltexinfo;
+
+    // Texinfo pointer, sizeof(csurface_t) * num surfaces
+    wasm_address_t surfaces;
+
+    // Four vec3_t for the pmove wrapper
+    wasm_address_t vectors;
+
+    // A wasm_trace_t that is used for the pmove wrapper
+    wasm_address_t trace;
+
+    // A usercmd_t used for ClientThink
+    wasm_address_t usercmd;
+
+    // Strings used by SpawnEntities
+    wasm_address_t mapname, entstring, spawnpoint;
+} wasm_mem_t;
+
+static wasm_export_t wasm_ge;
+static wasm_mem_t wasm_mem;
+
+static wasm_module_t module;
+static wasm_module_inst_t module_inst;
+static wasm_exec_env_t exec_env;
+static byte *wasm_binary;
+static int wasm_size;
+static char wasm_error[MAXERRORMSG];
+static char wasi_dir[2][MAX_QPATH];
+static char wasi_dir_map[2][MAX_OSPATH];
+static const char *wasi_dirs[2] = {
+    wasi_dir[0],
+    wasi_dir[1]
+};
+static const char *wasi_dir_maps[2] = {
+    wasi_dir_map[0],
+    wasi_dir_map[1]
+};
+static size_t wasi_num_dirs;
+
+wasm_address_t SV_AllocateWASMMemory(uint32_t size)
+{
+    return wasm_runtime_module_malloc(module_inst, size, NULL);
+}
+
+void SV_FreeWASMMemory(wasm_address_t addr)
+{
+    wasm_runtime_module_free(module_inst, addr);
+}
+
+/*
+===============
+SV_ValidateWASMAddress
+
+Checks that a given address range is within valid WASM memory.
+===============
+*/
+bool SV_ValidateWASMAddress(wasm_address_t address, uint32_t size)
+{
+    return wasm_runtime_validate_app_addr(module_inst, address, size);
+}
+
+/*
+===============
+SV_ValidateWASMEntity
+
+Checks that a given address is a valid entity. This will also
+allow null (zero) as a valid option.
+===============
+*/
+bool SV_ValidateWASMEntityAddress(wasm_address_t address)
+{
+    return !address || ((address >= wasm_ge.edicts && address <= wasm_ge.edicts_end - wasm_ge.edict_size) &&
+        ((address - wasm_ge.edicts) % wasm_ge.edict_size == 0) && SV_ValidateWASMAddress(address, wasm_ge.edict_size));
+}
+
+/*
+===============
+SV_ResolveWASMAddress
+
+Return native memory location of a given WASM address.
+===============
+*/
+void *SV_ResolveWASMAddress(wasm_address_t address)
+{
+    if (!address)
+        return NULL;
+
+    return wasm_runtime_addr_app_to_native(module_inst, address);
+}
+
+/*
+===============
+SV_UnresolveWASMAddress
+
+Return WASM memory location of a given native address.
+===============
+*/
+wasm_address_t SV_UnresolveWASMAddress(void *pointer)
+{
+    if (pointer == NULL)
+        return 0;
+
+    return wasm_runtime_addr_native_to_app(module_inst, pointer);
+}
+
+/*
+===============
+SV_CallWASMFunction
+
+Call a function from the WASM module. You're responsible for making sure the
+passed arguments pointer can hold the inputs *and* outputs of the function. Note
+that results from WASM functions are written into this argument array!
+===============
+*/
+void SV_CallWASMFunction(wasm_function_t function, uint32_t argc, uint32_t argv[])
+{
+    if (!wasm_runtime_call_wasm(exec_env, function, argc, argv)) {
+        Com_Error(ERR_FATAL, "%s: error in execution of function: %s", __func__, wasm_runtime_get_exception(module_inst));
+    }
+}
+
+/*
+===============
+SV_GetWASMFunction
+
+Fetch a function from the WASM module, returning its pointer if it exists,
+otherwise returning NULL.
+===============
+*/
+wasm_function_t SV_GetWASMFunction(const char *name, const char *signature, bool fatal)
+{
+    wasm_function_inst_t *func = wasm_runtime_lookup_function(module_inst, name, signature);
+
+    if (!func && fatal) {
+        Com_Error(ERR_FATAL, "%s: couldn't find function: %s", __func__, name);
+    }
+
+    return func;
+}
+
+bool SV_IsWASMRunning(void)
+{
+    return wasm_ge.loaded;
+}
+
+typedef struct {
+    uint32_t tag;
+    wasm_address_t address;
+
+    list_t list;
+} wasm_tagged_mem_t;
+
+static list_t tagged_memory;
+
+static void SV_ShutdownGameWasm(void)
+{
+	if (exec_env) {
+		wasm_runtime_destroy_exec_env(exec_env);
+        exec_env = NULL;
+    }
+
+	if (module_inst) {
+		wasm_runtime_deinstantiate(module_inst);
+        module_inst = NULL;
+    }
+
+	if (module) {
+		wasm_runtime_unload(module);
+        module = NULL;
+    }
+
+    if (wasm_binary) {
+        FS_FreeFile(wasm_binary);
+        wasm_binary = NULL;
+        wasm_size = 0;
+    }
+
+	wasm_runtime_destroy();
+
+    memset(&wasm_ge, 0, sizeof(wasm_ge));
+    memset(&wasm_mem, 0, sizeof(wasm_mem));
+
+    Cvar_DestroyWASMLinkage();
+
+    Z_FreeTags(TAG_WASM);
+
+    List_Init(&tagged_memory);
+}
+
+static bool _SV_LoadGameWasm(const char *path)
+{
+    int ret = FS_LoadFileEx(path, (void **) &wasm_binary, FS_PATH_GAME | FS_PATH_BASE, TAG_FILESYSTEM);
+
+    if (!wasm_binary) {
+        if (ret != Q_ERR_NOENT) {
+            Com_EPrintf("Failed to load game WASM %s: %s\n", path, Q_ErrorString(ret));
+        }
+        return false;
+    }
+
+    wasm_size = ret;
+    return true;
+}
+
+static bool SV_LoadGameWasm(const char *game, const char *prefix)
+{
+    char path[MAX_OSPATH];
+
+    if (Q_concat(path, sizeof(path), prefix, "game" WASMSUFFIX) >= sizeof(path)) {
+        Com_EPrintf("Game WASM path length exceeded\n");
+        return false;
+    }
+
+    return _SV_LoadGameWasm(path);
+}
+
+/*
+===============
+SV_SetWASMEntityPointers
+
+Set the current addresses of num_edicts and edicts.
+These may change during a game load, so we have to be sure
+to fetch their new addresses.
+===============
+*/
+void SV_SetWASMEntityPointers(void)
+{
+    uint32_t args[1];
+
+    SV_CallWASMFunction(wasm_ge.GetNumEdicts, 0, args);
+    wasm_ge.num_edicts = args[0];
+
+    SV_CallWASMFunction(wasm_ge.GetEdicts, 0, args);
+    wasm_ge.edicts = args[0];
+
+    wasm_ge.edicts_end = wasm_ge.edicts + (ge->pool.max_edicts * wasm_ge.edict_size);
+}
+
+typedef struct {
+	entity_state_t	s;
+	uint32_t		client;
+	qboolean		inuse;
+	int32_t			linkcount;
+
+	int32_t	area_next, area_prev;
+
+	int32_t	num_clusters;
+	int32_t	clusternums[MAX_ENT_CLUSTERS];
+	int32_t	headnode;
+	int32_t	areanum, areanum2;
+
+	int32_t     	svflags;
+	vec3_t			mins, maxs;
+	vec3_t			absmin, absmax, size;
+	solid_t			solid;
+	int32_t         clipmask;
+	wasm_address_t	owner;
+} wasm_edict_t;
+
+/*
+
+    int     number;         // edict index
+
+    vec3_t  origin;
+    vec3_t  angles;
+    vec3_t  old_origin;     // for lerping
+    int     modelindex;
+    int     modelindex2, modelindex3, modelindex4;  // weapons, CTF flags, etc
+    int     frame;
+    int     skinnum;
+    unsigned int        effects;        // PGM - we're filling it, so it needs to be unsigned
+    int     renderfx;
+    int     solid;          // for client side prediction, 8*(bits 0-4) is x/y radius
+                            // 8*(bits 5-9) is z down distance, 8(bits10-15) is z up
+                            // gi.linkentity sets this properly
+    int     sound;          // for looping sounds, to guarantee shutoff
+    int     event;          // impulse events -- muzzle flashes, footsteps, etc
+                            // events only go out for a single frame, they
+                            // are automatically cleared each frame
+*/
+
+typedef struct {
+    struct {
+        wasm_field_t    number;
+
+        wasm_field_t    origin;
+        wasm_field_t    angles;
+        wasm_field_t    old_origin;
+        wasm_field_t    modelindex;
+        wasm_field_t    modelindex2, modelindex3, modelindex4;
+        wasm_field_t    frame;
+        wasm_field_t    skinnum;
+        wasm_field_t    effects;
+        wasm_field_t    renderfx;
+        wasm_field_t    solid;
+
+        wasm_field_t    sound;
+        wasm_field_t    event;
+    } s;
+
+    wasm_field_t    client;
+    wasm_field_t    inuse;
+    wasm_field_t    linkcount;
+
+    wasm_field_t    area_prev;
+
+    wasm_field_t    areanum, areanum2;
+
+    wasm_field_t    svflags;
+    wasm_field_t    mins, maxs;
+    wasm_field_t    absmin, absmax, size;
+    wasm_field_t    solid;
+    wasm_field_t    clipmask;
+    wasm_field_t    owner;
+} wasm_edict_layout_t;
+
+#define WASM_FIELD(t, member, n) \
+    { t, (uint32_t) offsetof(wasm_edict_t, member), n }
+
+static wasm_edict_layout_t wasm_standard_edict_layout = {
+    {
+        WASM_FIELD(WF_INT32, s.number, 1),
+        
+        WASM_FIELD(WF_FLOAT32, s.origin, 3),
+        WASM_FIELD(WF_FLOAT32, s.angles, 3),
+        WASM_FIELD(WF_FLOAT32, s.old_origin, 3),
+        
+        WASM_FIELD(WF_INT32, s.modelindex, 1),
+        WASM_FIELD(WF_INT32, s.modelindex2, 1),
+        WASM_FIELD(WF_INT32, s.modelindex3, 1),
+        WASM_FIELD(WF_INT32, s.modelindex4, 1),
+        WASM_FIELD(WF_INT32, s.frame, 1),
+        WASM_FIELD(WF_INT32, s.skinnum, 1),
+        WASM_FIELD(WF_INT32 | WF_UNSIGNED, s.effects, 1),
+        WASM_FIELD(WF_INT32, s.renderfx, 1),
+        WASM_FIELD(WF_INT32, s.solid, 1),
+
+        WASM_FIELD(WF_INT32, s.sound, 1),
+        WASM_FIELD(WF_INT32, s.event, 1),
+    },
+
+    WASM_FIELD(WF_POINTER, client, 1),
+    WASM_FIELD(WF_INT32, inuse, 1),
+    WASM_FIELD(WF_INT32, linkcount, 1),
+
+    WASM_FIELD(WF_INT32, area_prev, 1),
+
+    WASM_FIELD(WF_INT32, areanum, 1),
+    WASM_FIELD(WF_INT32, areanum2, 1),
+
+    WASM_FIELD(WF_INT32, svflags, 1),
+    WASM_FIELD(WF_FLOAT32, mins, 3),
+    WASM_FIELD(WF_FLOAT32, maxs, 3),
+    WASM_FIELD(WF_FLOAT32, absmin, 3),
+    WASM_FIELD(WF_FLOAT32, absmax, 3),
+    WASM_FIELD(WF_FLOAT32, size, 3),
+    WASM_FIELD(WF_INT32, solid, 1),
+    WASM_FIELD(WF_INT32, clipmask, 1),
+    WASM_FIELD(WF_POINTER, owner, 1)
+};
+
+#undef WASM_FIELD
+
+// WASM entity management
+static inline edict_t *entity_number_to_native(int32_t i)
+{
+    return &ge->pool.edicts[i];
+}
+
+static inline wasm_edict_t *entity_number_to_wasm(int32_t i)
+{
+    return SV_ResolveWASMAddress(wasm_ge.edicts + (wasm_ge.edict_size * i));
+}
+
+static inline edict_t *entity_wasm_to_native(uint32_t address)
+{
+    if (!address)
+        return NULL;
+
+    return &ge->pool.edicts[(address - wasm_ge.edicts) / wasm_ge.edict_size];
+}
+
+static inline uint32_t entity_native_to_wasm(edict_t *e)
+{
+    if (e == NULL)
+        return 0;
+
+    return wasm_ge.edicts + ((e - ge->pool.edicts) * wasm_ge.edict_size);
+}
+
+static inline void copy_link_wasm_to_native(edict_t *native_edict, const wasm_edict_t *wasm_edict)
+{
+	native_edict->s = wasm_edict->s;
+	native_edict->inuse = wasm_edict->inuse;
+	native_edict->svflags = wasm_edict->svflags;
+	VectorCopy(wasm_edict->mins, native_edict->mins);
+	VectorCopy(wasm_edict->maxs, native_edict->maxs);
+	native_edict->clipmask = wasm_edict->clipmask;
+	native_edict->solid = wasm_edict->solid;
+	native_edict->linkcount = wasm_edict->linkcount;
+}
+
+static inline void copy_link_native_to_wasm(wasm_edict_t *wasm_edict, const edict_t *native_edict)
+{
+    if (wasm_edict->linkcount == native_edict->linkcount)
+        return;
+
+	wasm_edict->area_next = native_edict->area.next ? 1 : 0;
+	wasm_edict->area_prev = native_edict->area.prev ? 1 : 0;
+	wasm_edict->linkcount = native_edict->linkcount;
+	wasm_edict->areanum = native_edict->areanum;
+	wasm_edict->areanum2 = native_edict->areanum2;
+	VectorCopy(native_edict->absmin, wasm_edict->absmin);
+	VectorCopy(native_edict->absmax, wasm_edict->absmax);
+	VectorCopy(native_edict->size, wasm_edict->size);
+	wasm_edict->s.solid = native_edict->s.solid;
+	wasm_edict->linkcount = native_edict->linkcount;
+}
+
+static inline void copy_frame_native_to_wasm(wasm_edict_t *wasm_edict, const edict_t *native_edict)
+{
+	wasm_edict->s.number = native_edict->s.number;
+	wasm_edict->s.event = native_edict->s.event;
+}
+
+static inline bool should_sync_entity(const wasm_edict_t *wasm_edict, const edict_t *native)
+{
+	return (!wasm_edict->client != !native->client ||
+		wasm_edict->inuse != native->inuse ||
+		wasm_edict->inuse);
+}
+
+static inline void sync_entity(wasm_edict_t *wasm_edict, edict_t *native, bool force)
+{
+	// Don't bother syncing non-inuse entities.
+	if (!force && !should_sync_entity(wasm_edict, native))
+		return;
+
+	// sync main data
+	copy_link_wasm_to_native(native, wasm_edict);
+
+	// fill owner pointer
+	native->owner = entity_wasm_to_native(wasm_edict->owner);
+
+	// sync client structure, if it exists
+	if (wasm_edict->client)
+	{
+		if (!native->client)
+			native->client = Z_TagMalloc(sizeof(gclient_t), TAG_WASM);
+
+		size_t client_struct_size = sizeof(gclient_t);
+
+		if (g_features->integer & GMF_CLIENTNUM)
+			client_struct_size -= sizeof(int32_t);
+
+		memcpy(native->client, SV_ResolveWASMAddress(wasm_edict->client), client_struct_size);
+	}
+	else
+	{
+		if (native->client)
+		{
+			Z_Free(native->client);
+			native->client = NULL;
+		}
+	}
+}
+
+static void pre_sync_entities(void)
+{
+	for (int32_t i = 0; i < ge->pool.num_edicts; i++)
+		copy_frame_native_to_wasm(entity_number_to_wasm(i), entity_number_to_native(i));
+}
+
+static void post_sync_entities(void)
+{
+	const int32_t wasm_num = *(int32_t *)SV_ResolveWASMAddress(wasm_ge.num_edicts);
+
+	const int32_t num_sync = max(ge->pool.num_edicts, wasm_num);
+
+	ge->pool.num_edicts = wasm_num;
+
+	for (int32_t i = 0; i < num_sync; i++)
+		sync_entity(entity_number_to_wasm(i), entity_number_to_native(i), false);
+}
+
+#define WASM_MEMORY_VALIDATE_NO_NULL(addr, size) \
+	if (!addr || !SV_ValidateWASMAddress(addr, size)) { \
+        Com_Error(ERR_DROP, "%s: invalid pointer passed for argument %s", __func__, #addr); \
+    }
+
+#define WASM_ENTITY_VALIDATE_NO_NULL(addr) \
+	if (!addr || !SV_ValidateWASMEntityAddress(addr)) { \
+        Com_Error(ERR_DROP, "%s: invalid entity pointer passed for argument %s", __func__, #addr); \
+    }
+
+#define WASM_ENTITY_VALIDATE(addr) \
+	if (!SV_ValidateWASMEntityAddress(addr)) { \
+        Com_Error(ERR_DROP, "%s: invalid entity pointer passed for argument %s", __func__, #addr); \
+    }
+
+static void PF_wasm_dprint(wasm_exec_env_t env, const char *str)
+{
+    Com_Printf("%s", str);
+}
+
+static void PF_wasm_bprint(wasm_exec_env_t env, int print_level, const char *str)
+{
+    PF_bprintf(print_level, "%s", str);
+}
+
+static uint32_t PF_wasm_cvar(wasm_exec_env_t env, const char *name, const char *value, int32_t flags)
+{
+    return PF_cvar(name, value, flags)->wasm;
+}
+
+static uint32_t PF_wasm_cvar_set(wasm_exec_env_t env, const char *name, const char *value)
+{
+    return Cvar_UserSet(name, value)->wasm;
+}
+
+static uint32_t PF_wasm_cvar_forceset(wasm_exec_env_t env, const char *name, const char *value)
+{
+    return Cvar_Set(name, value)->wasm;
+}
+
+static uint32_t PF_wasm_TagMalloc(wasm_exec_env_t env, uint32_t size, uint32_t tag)
+{
+	wasm_address_t loc = SV_AllocateWASMMemory(size);
+
+	if (!loc) {
+        Com_Error(ERR_DROP, "%s: out of memory", __func__);
+    }
+
+    wasm_tagged_mem_t *tagged = Z_TagMalloc(sizeof(wasm_tagged_mem_t), TAG_WASM);
+    tagged->tag = tag;
+    tagged->address = loc;
+    List_Append(&tagged_memory, &tagged->list);
+
+    return loc;
+}
+
+static void PF_wasm_TagFree(wasm_exec_env_t env, uint32_t ptr)
+{
+    wasm_tagged_mem_t *block;
+    bool found = false;
+
+    LIST_FOR_EACH(wasm_tagged_mem_t, block, &tagged_memory, list) {
+        if (block->address == ptr) {
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        Com_Error(ERR_DROP, "%s: bad memory block", __func__);
+    }
+
+    List_Remove(&block->list);
+
+	SV_FreeWASMMemory(block->address);
+
+    Z_Free(block);
+}
+
+static void PF_wasm_FreeTags(wasm_exec_env_t env, uint32_t tag)
+{
+    wasm_tagged_mem_t *block, *next;
+
+    LIST_FOR_EACH_SAFE(wasm_tagged_mem_t, block, next, &tagged_memory, list) {
+        if (block->tag == tag) {
+            List_Remove(&block->list);
+	        SV_FreeWASMMemory(block->address);
+            Z_Free(block);
+        }
+    }
+}
+
+static void PF_wasm_configstring(wasm_exec_env_t env, int32_t id, const char *value)
+{
+    PF_configstring(id, value);
+}
+
+static int32_t PF_wasm_modelindex(wasm_exec_env_t env, const char *name)
+{
+    return PF_ModelIndex(name);
+}
+
+static int32_t PF_wasm_imageindex(wasm_exec_env_t env, const char *name)
+{
+    return PF_ImageIndex(name);
+}
+
+static int32_t PF_wasm_soundindex(wasm_exec_env_t env, const char *name)
+{
+    return PF_SoundIndex(name);
+}
+
+static void PF_wasm_cprint(wasm_exec_env_t env, wasm_address_t wasm_edict, int print_level, const char *str)
+{
+    WASM_ENTITY_VALIDATE_NO_NULL(wasm_edict);
+    
+	edict_t *native = entity_wasm_to_native(wasm_edict);
+
+    PF_cprintf(native, print_level, "%s", str);
+}
+
+static void PF_wasm_centerprint(wasm_exec_env_t env, wasm_address_t wasm_edict, const char *str)
+{
+    WASM_ENTITY_VALIDATE_NO_NULL(wasm_edict);
+    
+	edict_t *native = entity_wasm_to_native(wasm_edict);
+
+    PF_centerprintf(native, "%s", str);
+}
+
+static void PF_wasm_error(wasm_exec_env_t env, const char *str)
+{
+    Com_Error(ERR_DROP, "Game Error: %s", str);
+}
+
+static void PF_wasm_linkentity(wasm_exec_env_t env, wasm_address_t wasm_addr)
+{
+    WASM_ENTITY_VALIDATE_NO_NULL(wasm_addr);
+    
+	edict_t *native_edict = entity_wasm_to_native(wasm_addr);
+    wasm_edict_t *wasm_edict = SV_ResolveWASMAddress(wasm_addr);
+
+	copy_link_wasm_to_native(native_edict, wasm_edict);
+	const bool copy_old_origin = wasm_edict->linkcount == 0;
+    PF_LinkEdict(native_edict);
+	if (copy_old_origin)
+		VectorCopy(native_edict->s.old_origin, wasm_edict->s.old_origin);
+	copy_link_native_to_wasm(wasm_edict, native_edict);
+}
+
+static void PF_wasm_unlinkentity(wasm_exec_env_t env, wasm_address_t wasm_addr)
+{
+    WASM_ENTITY_VALIDATE_NO_NULL(wasm_addr);
+    
+	edict_t *native_edict = entity_wasm_to_native(wasm_addr);
+    wasm_edict_t *wasm_edict = SV_ResolveWASMAddress(wasm_addr);
+
+	copy_link_wasm_to_native(native_edict, wasm_edict);
+    PF_UnlinkEdict(native_edict);
+	copy_link_native_to_wasm(wasm_edict, native_edict);
+}
+
+static void PF_wasm_setmodel(wasm_exec_env_t env, wasm_address_t wasm_addr, const char *model)
+{
+    WASM_ENTITY_VALIDATE_NO_NULL(wasm_addr);
+    
+	edict_t *native_edict = entity_wasm_to_native(wasm_addr);
+    wasm_edict_t *wasm_edict = SV_ResolveWASMAddress(wasm_addr);
+
+	copy_link_wasm_to_native(native_edict, wasm_edict);
+    PF_setmodel(native_edict, model);
+	copy_link_native_to_wasm(wasm_edict, native_edict);
+
+	// setmodel also sets up mins, maxs, and modelindex
+	wasm_edict->s.modelindex = native_edict->s.modelindex;
+	VectorCopy(native_edict->mins, wasm_edict->mins);
+	VectorCopy(native_edict->maxs, wasm_edict->maxs);
+}
+
+typedef struct
+{
+	qboolean		allsolid;
+	qboolean		startsolid;
+	vec_t			fraction;
+	vec3_t			endpos;
+	cplane_t		plane;
+	wasm_address_t	surface;
+	int             contents;
+	wasm_address_t  ent;
+} wasm_trace_t;
+
+static wasm_address_t wasm_pmove_addr;
+extern mtexinfo_t nulltexinfo;
+
+static trace_t wasm_pmove_trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end)
+{
+	uint32_t args[] = {
+		wasm_pmove_addr,
+		*(uint32_t *) (&start[0]),
+		*(uint32_t *) (&start[1]),
+		*(uint32_t *) (&start[2]),
+		*(uint32_t *) (&mins[0]),
+		*(uint32_t *) (&mins[1]),
+		*(uint32_t *) (&mins[2]),
+		*(uint32_t *) (&maxs[0]),
+		*(uint32_t *) (&maxs[1]),
+		*(uint32_t *) (&maxs[2]),
+		*(uint32_t *) (&end[0]),
+		*(uint32_t *) (&end[1]),
+		*(uint32_t *) (&end[2]),
+		wasm_mem.trace
+	};
+
+    SV_CallWASMFunction(wasm_ge.PmoveTrace, 14, args);
+
+	wasm_trace_t *wasm_tr = SV_ResolveWASMAddress(wasm_mem.trace);
+	static trace_t tr;
+
+	tr.allsolid = wasm_tr->allsolid;
+	tr.contents = wasm_tr->contents;
+	VectorCopy(wasm_tr->endpos, tr.endpos);
+	tr.ent = entity_wasm_to_native(wasm_tr->ent);
+	tr.fraction = wasm_tr->fraction;
+	tr.plane = wasm_tr->plane;
+	tr.startsolid = wasm_tr->startsolid;
+
+	if (wasm_tr->surface == wasm_mem.nulltexinfo) {
+		tr.surface = &(nulltexinfo.c);
+    } else {
+		tr.surface = &(sv.cm.cache->texinfo[(wasm_tr->surface - wasm_mem.surfaces) / sizeof(csurface_t)].c);
+    }
+
+	return tr;
+}
+
+static int wasm_pmove_pointcontents(vec3_t start)
+{
+	uint32_t args[] = {
+		wasm_pmove_addr,
+		*(uint32_t *) (&start[0]),
+		*(uint32_t *) (&start[1]),
+		*(uint32_t *) (&start[2]),
+	};
+
+    SV_CallWASMFunction(wasm_ge.PmovePointContents, 4, args);
+
+	return args[0];
+}
+
+typedef struct
+{
+	// state (in / out)
+	pmove_state_t	s;
+
+	// command (in)
+	usercmd_t	cmd;
+	qboolean	snapinitial;    // if s has been changed outside pmove
+
+	// results (out)
+	int32_t	numtouch;
+	wasm_address_t touchents[MAXTOUCH];
+
+	vec3_t	viewangles;         // clamped
+	vec_t	viewheight;
+
+	vec3_t	mins, maxs;         // bounding box size
+
+	wasm_address_t groundentity;
+	int32_t	watertype;
+	int32_t	waterlevel;
+
+	// callbacks to test the world
+	wasm_address_t trace;
+	wasm_address_t pointcontents;
+} wasm_pmove_t;
+
+static void PF_wasm_Pmove(wasm_exec_env_t env, wasm_address_t wasm_pmove)
+{
+    WASM_MEMORY_VALIDATE_NO_NULL(wasm_pmove, sizeof(wasm_pmove_t));
+
+	static pmove_t pm;
+    wasm_pmove_t *wasm_pm = SV_ResolveWASMAddress(wasm_pmove);
+
+	pm.s = wasm_pm->s;
+	pm.cmd = wasm_pm->cmd;
+	pm.snapinitial = wasm_pm->snapinitial;
+
+	pm.trace = wasm_pmove_trace;
+	pm.pointcontents = wasm_pmove_pointcontents;
+
+	wasm_pmove_addr = wasm_pmove;
+
+    PF_Pmove(&pm);
+
+    wasm_pm = SV_ResolveWASMAddress(wasm_pmove);
+
+	wasm_pm->s = pm.s;
+	wasm_pm->numtouch = pm.numtouch;
+	for (int32_t i = 0; i < pm.numtouch; i++)
+		wasm_pm->touchents[i] = entity_native_to_wasm(pm.touchents[i]);
+	VectorCopy(pm.viewangles, wasm_pm->viewangles);
+	wasm_pm->viewheight = pm.viewheight;
+	VectorCopy(pm.mins, wasm_pm->mins);
+	VectorCopy(pm.maxs, wasm_pm->maxs);
+	wasm_pm->groundentity = entity_native_to_wasm(pm.groundentity);
+	wasm_pm->watertype = pm.watertype;
+	wasm_pm->waterlevel = pm.waterlevel;
+}
+
+static void PF_wasm_trace(wasm_exec_env_t env, float start_x, float start_y, float start_z, float mins_x, float mins_y, float mins_z, float maxs_x, float maxs_y, float maxs_z,
+    float end_x, float end_y, float end_z, wasm_address_t passent, int contentmask, wasm_address_t out)
+{
+    WASM_ENTITY_VALIDATE(passent);
+    WASM_MEMORY_VALIDATE_NO_NULL(out, sizeof(wasm_trace_t));
+
+    post_sync_entities();
+
+    trace_t tr = SV_Trace((float[]) { start_x, start_y, start_z }, (float[]) { mins_x, mins_y, mins_z },
+        (float[]) { maxs_x, maxs_y, maxs_z }, (float[]) { end_x, end_y, end_z }, entity_wasm_to_native(passent), contentmask);
+
+    wasm_trace_t *out_tr = SV_ResolveWASMAddress(out);
+
+	out_tr->allsolid = tr.allsolid;
+	out_tr->contents = tr.contents;
+	VectorCopy(tr.endpos, out_tr->endpos);
+	out_tr->ent = entity_native_to_wasm(tr.ent);
+	out_tr->fraction = tr.fraction;
+	out_tr->plane = tr.plane;
+	out_tr->startsolid = tr.startsolid;
+
+	if (!tr.surface || !tr.surface->name[0]) {
+		out_tr->surface = wasm_mem.nulltexinfo;
+    } else {
+        out_tr->surface = wasm_mem.surfaces + ((((mtexinfo_t *)tr.surface) - sv.cm.cache->texinfo) * sizeof(csurface_t));
+    }
+}
+
+static int PF_wasm_pointcontents(wasm_exec_env_t env, float p_x, float p_y, float p_z)
+{
+    post_sync_entities();
+
+    return SV_PointContents((float []) { p_x, p_y, p_z });
+}
+
+static void PF_wasm_WriteAngle(wasm_exec_env_t env, float c)
+{
+	MSG_WriteAngle(c);
+}
+
+static void PF_wasm_WriteByte(wasm_exec_env_t env, int c)
+{
+	MSG_WriteByte(c);
+}
+
+static void PF_wasm_WriteChar(wasm_exec_env_t env, int c)
+{
+	MSG_WriteChar(c);
+}
+
+static void PF_wasm_WriteDir(wasm_exec_env_t env, float p_x, float p_y, float p_z)
+{
+    MSG_WriteDir((const float[]) { p_x, p_y, p_z });
+}
+
+static void PF_wasm_WriteFloat(wasm_exec_env_t env, float p)
+{
+    PF_WriteFloat(p);
+}
+
+static void PF_wasm_WriteLong(wasm_exec_env_t env, int p)
+{
+	MSG_WriteLong(p);
+}
+
+static void PF_wasm_WritePosition(wasm_exec_env_t env, float p_x, float p_y, float p_z)
+{
+    MSG_WritePos((const float[]) { p_x, p_y, p_z });
+}
+
+static void PF_wasm_WriteShort(wasm_exec_env_t env, int p)
+{
+    MSG_WriteShort(p);
+}
+
+static void PF_wasm_WriteString(wasm_exec_env_t env, const char *p)
+{
+    MSG_WriteString(p);
+}
+
+static void PF_wasm_unicast(wasm_exec_env_t env, wasm_address_t ent, qboolean reliable)
+{
+    WASM_ENTITY_VALIDATE_NO_NULL(ent);
+    
+	edict_t *native = entity_wasm_to_native(ent);
+
+    PF_Unicast(native, reliable);
+}
+
+static void PF_wasm_multicast(wasm_exec_env_t env, float origin_x, float origin_y, float origin_z, multicast_t to)
+{
+    SV_Multicast((float[]) { origin_x, origin_y, origin_z }, to);
+}
+
+static int PF_wasm_BoxEdicts(wasm_exec_env_t env, float mins_x, float mins_y, float mins_z, float maxs_x, float maxs_y, float maxs_z, wasm_address_t list, int maxcount, int areatype)
+{
+    WASM_MEMORY_VALIDATE_NO_NULL(list, sizeof(uint32_t) * maxcount);
+
+    post_sync_entities();
+
+#ifdef _MSC_VER
+    edict_t **list_native = _malloca(sizeof(edict_t *) * maxcount);
+
+    if (!list_native) {
+        Com_Error(ERR_DROP, "%s: stack overflow", __func__);
+    }
+#else
+    edict_t *list_native[maxcount];
+#endif
+
+    int count = SV_AreaEdicts((float[]) { mins_x, mins_y, mins_z }, (float[]) { maxs_x, maxs_y, maxs_z }, list_native, maxcount, areatype);
+
+    uint32_t *list_wasm = SV_ResolveWASMAddress(list);
+
+	for (int32_t i = 0; i < count; i++)
+		list_wasm[i] = entity_native_to_wasm(list_native[i]);
+
+	return count;
+}
+
+static void PF_wasm_sound(wasm_exec_env_t env, wasm_address_t ent, int channel, int soundindex, float volume, float attenuation, float timeofs)
+{
+    WASM_ENTITY_VALIDATE_NO_NULL(ent);
+
+	edict_t *native = entity_wasm_to_native(ent);
+
+	sync_entity(SV_ResolveWASMAddress(ent), native, false);
+
+    PF_StartSound(native, channel, soundindex, volume, attenuation, timeofs);
+}
+
+static void PF_wasm_positioned_sound(wasm_exec_env_t env, float origin_x, float origin_y, float origin_z, wasm_address_t ent, int channel, int soundindex, float volume, float attenuation, float timeofs)
+{
+    WASM_ENTITY_VALIDATE_NO_NULL(ent);
+    
+	edict_t *native = entity_wasm_to_native(ent);
+
+	sync_entity(SV_ResolveWASMAddress(ent), native, false);
+
+    SV_StartSound(isfinite(origin_x) ? (float[]) { origin_x, origin_y, origin_z } : NULL, native, channel, soundindex, volume, attenuation, timeofs);
+}
+
+static int32_t PF_wasm_argc(wasm_exec_env_t env)
+{
+    return Cmd_Argc();
+}
+
+static uint32_t PF_wasm_argv(wasm_exec_env_t env, int32_t i)
+{
+    return 0;
+	/*if (i < 0 || i >= sizeof(wasm_buffers_t::cmds) / sizeof(*wasm_buffers_t::cmds))
+		return 0;
+
+	return WASM_BUFFERS_OFFSET(cmds[i]);*/
+}
+
+static uint32_t PF_wasm_args(wasm_exec_env_t env)
+{
+    return 0;
+	//return WASM_BUFFERS_OFFSET(scmd);
+}
+
+static void PF_wasm_AddCommandString(wasm_exec_env_t env, const char *string)
+{
+    PF_AddCommandString(string);
+}
+
+static qboolean PF_wasm_AreasConnected(wasm_exec_env_t env, int area1, int area2)
+{
+    return PF_AreasConnected(area1, area2);
+}
+
+static qboolean PF_wasm_inPHS(wasm_exec_env_t env, float p1_x, float p1_y, float p1_z, float p2_x, float p2_y, float p2_z)
+{
+    return PF_inPHS((float[]) { p1_x, p1_y, p1_z }, (float[]) { p2_x, p2_y, p2_z });
+}
+
+static qboolean PF_wasm_inPVS(wasm_exec_env_t env, float p1_x, float p1_y, float p1_z, float p2_x, float p2_y, float p2_z)
+{
+    return PF_inPVS((float[]) { p1_x, p1_y, p1_z }, (float[]) { p2_x, p2_y, p2_z });
+}
+
+static void PF_wasm_SetAreaPortalState(wasm_exec_env_t env, int portal, qboolean state)
+{
+    PF_SetAreaPortalState(portal, state);
+}
+
+static void PF_wasm_DebugGraph(wasm_exec_env_t env, float value, int color)
+{
+    PF_DebugGraph(value, color);
+}
+
+static game_capability_t PF_wasm_QueryEngineCapability(wasm_exec_env_t env, const char *cap)
+{
+    return false;
+}
+
+static bool SV_RegisterGameImports(void)
+{
+#define WASM_SYMBOL(name, sig) \
+	{ #name, (void *) PF_wasm_ ## name, sig, NULL }
+
+    static NativeSymbol native_symbols[] = {
+	    WASM_SYMBOL(dprint, "($)"),
+	    WASM_SYMBOL(bprint, "(i$)"),
+	    WASM_SYMBOL(cprint, "(ii$)"),
+	    WASM_SYMBOL(error, "(*)"),
+	    WASM_SYMBOL(centerprint, "(i$)"),
+	    WASM_SYMBOL(cvar, "($$i)i"),
+	    WASM_SYMBOL(cvar_set, "($$)i"),
+	    WASM_SYMBOL(cvar_forceset, "($$)i"),
+	    WASM_SYMBOL(TagMalloc, "(ii)i"),
+	    WASM_SYMBOL(TagFree, "(i)"),
+	    WASM_SYMBOL(FreeTags, "(i)"),
+	    WASM_SYMBOL(configstring, "(i$)"),
+	    WASM_SYMBOL(modelindex, "($)i"),
+	    WASM_SYMBOL(imageindex, "($)i"),
+	    WASM_SYMBOL(soundindex, "($)i"),
+	    WASM_SYMBOL(linkentity, "(i)"),
+	    WASM_SYMBOL(unlinkentity, "(i)"),
+	    WASM_SYMBOL(setmodel, "(i$)"),
+	    WASM_SYMBOL(Pmove, "(i)"),
+	    WASM_SYMBOL(trace, "(ffffffffffffiii)"),
+	    WASM_SYMBOL(pointcontents, "(fff)i"),
+	    WASM_SYMBOL(WriteAngle, "(f)"),
+	    WASM_SYMBOL(WriteByte, "(i)"),
+	    WASM_SYMBOL(WriteChar, "(i)"),
+	    WASM_SYMBOL(WriteDir, "(fff)"),
+	    WASM_SYMBOL(WriteFloat, "(f)"),
+	    WASM_SYMBOL(WriteLong, "(i)"),
+	    WASM_SYMBOL(WritePosition, "(fff)"),
+	    WASM_SYMBOL(WriteShort, "(i)"),
+	    WASM_SYMBOL(WriteString, "($)"),
+	    WASM_SYMBOL(unicast, "(ii)"),
+	    WASM_SYMBOL(multicast, "(fffi)"),
+	    WASM_SYMBOL(BoxEdicts, "(ffffffiii)i"),
+	    WASM_SYMBOL(sound, "(iiifff)"),
+	    WASM_SYMBOL(positioned_sound, "(fffiiifff)"),
+	    WASM_SYMBOL(argc, "()i"),
+	    WASM_SYMBOL(argv, "(i)i"),
+	    WASM_SYMBOL(args, "()i"),
+	    WASM_SYMBOL(AddCommandString, "($)"),
+	    WASM_SYMBOL(AreasConnected, "(ii)i"),
+	    WASM_SYMBOL(inPHS, "(ii)i"),
+	    WASM_SYMBOL(inPVS, "(ii)i"),
+	    WASM_SYMBOL(SetAreaPortalState, "(ii)"),
+	    WASM_SYMBOL(DebugGraph, "(fi)"),
+	    WASM_SYMBOL(QueryEngineCapability, "($)i")
+    };
+
+#undef WASM_SYMBOL
+
+    return wasm_runtime_register_natives("q2", native_symbols, sizeof(native_symbols) / sizeof(*native_symbols));
+}
+
+/*
+===============
+SV_InitGameWasm
+
+Attempt to load a WASM game subsystem for
+a new map. Returns false if we can't.
+===============
+*/
+static bool _SV_InitGameWasm(void)
+{
+    bool success = false;
+
+    // for debugging or `proxy' mods
+    if (sys_forcegamelib->string[0])
+        success = _SV_LoadGameWasm(sys_forcegamelib->string);
+
+    // try game first
+    if (!success && fs_game->string[0]) {
+        success = SV_LoadGameWasm(fs_game->string, "q2pro_");
+        if (!success)
+            success = SV_LoadGameWasm(fs_game->string, "");
+    }
+
+    // then try baseq2
+    if (!success) {
+        success = SV_LoadGameWasm(BASEGAME, "q2pro_");
+        if (!success)
+            success = SV_LoadGameWasm(BASEGAME, "");
+    }
+
+    // all paths failed
+    if (!success) {
+        Com_Printf("Failed to load game WASM.\n");
+        return false;
+    }
+
+    // got a game WASM, try initializing it.
+	if (!wasm_runtime_init()) {
+        Com_Printf("Failed to initialize WASM runtime.\n");
+        return false;
+    }
+
+    // register API callbacks
+    SV_RegisterGameImports();
+
+	// parse the WASM file from buffer and create a WASM module
+	module = wasm_runtime_load(wasm_binary, wasm_size, wasm_error, sizeof(wasm_error));
+
+    if (!module) {
+        Com_Printf("Failed to load WASM module: %s\n", wasm_error);
+        return false;
+    }
+
+    // set up basename map first
+    wasi_num_dirs = 1;
+
+    if (*fs_game->string) {
+        Q_strlcpy(wasi_dir[0], fs_game->string, sizeof(wasi_dir[0]));
+    } else {
+        Q_strlcpy(wasi_dir[0], BASEGAME, sizeof(wasi_dir[0]));
+    }
+
+    wasi_dir_map[0][0] = 0;
+    Q_concat(wasi_dir_map[0], sizeof(wasi_dir_map[0]), fs_gamedir);
+
+	wasm_runtime_set_wasi_args(module, wasi_dirs, wasi_num_dirs, wasi_dir_maps, wasi_num_dirs, NULL, 0, NULL, 0);
+
+	// create an instance of the WASM module (WASM linear memory is ready)
+	module_inst = wasm_runtime_instantiate(module, 8192, sys_wasmheapsize->integer, wasm_error, sizeof(wasm_error));
+
+	if (!module_inst) {
+        Com_Printf("Failed to instantiate WASM module: %s\n", wasm_error);
+        return false;
+    }
+
+    // create execution environment
+	exec_env = wasm_runtime_create_exec_env(module_inst, sys_wasmstacksize->integer);
+
+	if (!exec_env) {
+        Com_Printf("Failed to create WASM execution environment: %s\n", wasm_error);
+        return false;
+    }
+
+    // initialize WASI
+	wasm_function_t initialize_func = SV_GetWASMFunction("_initialize", NULL, true);
+
+    SV_CallWASMFunction(initialize_func, 0, NULL);
+
+    // it's a valid WASM module! It might still not be a valid mod binary, though.
+    // now, we find all of the linked functions.
+    uint32_t return_values[1] = { WASM_API_VERSION };
+
+	wasm_function_t GetGameAPI = SV_GetWASMFunction("GetGameAPI", "(i)i", true);
+
+    SV_CallWASMFunction(GetGameAPI, 1, return_values);
+
+    if (return_values[0] != WASM_API_VERSION) {
+        Com_Printf("Wasm library is version %d, expected %d\n",
+                  return_values[0], WASM_API_VERSION);
+        return false;
+    }
+
+	wasm_ge.GetEdicts = SV_GetWASMFunction("GetEdicts", "()i", true);
+	wasm_ge.GetNumEdicts = SV_GetWASMFunction("GetNumEdicts", "()*", true);
+
+	wasm_ge.PmoveTrace = SV_GetWASMFunction("PmoveTrace", "(******)", true);
+	wasm_ge.PmovePointContents = SV_GetWASMFunction("PmovePointContents", "(**)", true);
+	wasm_ge.Init = SV_GetWASMFunction("Init", NULL, true);
+	wasm_ge.SpawnEntities = SV_GetWASMFunction("SpawnEntities", "($$$)", true);
+	wasm_ge.ClientConnect = SV_GetWASMFunction("ClientConnect", "(*$)i", true);
+	wasm_ge.ClientBegin = SV_GetWASMFunction("ClientBegin", "(*)", true);
+	wasm_ge.ClientUserinfoChanged = SV_GetWASMFunction("ClientUserinfoChanged", "(*$)", true);
+	wasm_ge.ClientCommand = SV_GetWASMFunction("ClientCommand", "(*)", true);
+	wasm_ge.ClientDisconnect = SV_GetWASMFunction("ClientDisconnect", "(*)", true);
+	wasm_ge.ClientThink = SV_GetWASMFunction("ClientThink", "(**)", true);
+	wasm_ge.RunFrame = SV_GetWASMFunction("RunFrame", NULL, true);
+	wasm_ge.ServerCommand = SV_GetWASMFunction("ServerCommand", NULL, true);
+	wasm_ge.WriteGame = SV_GetWASMFunction("WriteGame", "($i)", true);
+	wasm_ge.ReadGame = SV_GetWASMFunction("ReadGame", "($)", true);
+	wasm_ge.WriteLevel = SV_GetWASMFunction("WriteLevel", "($)", true);
+	wasm_ge.ReadLevel = SV_GetWASMFunction("ReadLevel", "($)", true);
+
+	wasm_ge.QueryGameCapability = SV_GetWASMFunction("QueryGameCapability", "($)*", true);
+    
+    // from beyond this point, we mark as loaded so other subsystems can be made aware of
+    // memory allocations (cvar)
+    wasm_ge.loaded = true;
+
+    return true;
+}
+
+static void SV_InitGameWasm(void)
+{
+    // Static memory that persists for the entire game module life
+    wasm_mem.trace = SV_AllocateWASMMemory(sizeof(wasm_trace_t));
+    wasm_mem.vectors = SV_AllocateWASMMemory(sizeof(vec3_t) * 4);
+    wasm_mem.usercmd = SV_AllocateWASMMemory(sizeof(usercmd_t));
+
+    if (!wasm_mem.trace || !wasm_mem.vectors || !wasm_mem.usercmd) {
+        Com_Error(ERR_DROP, "Couldn't allocate WASM memory\n");
+    }
+
+    SV_CallWASMFunction(wasm_ge.Init, 0, NULL);
+
+    uint32_t return_values[1];
+
+	wasm_function_t GetMaxEdicts = SV_GetWASMFunction("GetMaxEdicts", "()i", true);
+
+    SV_CallWASMFunction(GetMaxEdicts, 0, return_values);
+    ge->pool.max_edicts = return_values[0];
+
+    // sanitize max_edicts
+    if (ge->pool.max_edicts <= sv_maxclients->integer || ge->pool.max_edicts > MAX_EDICTS) {
+        Com_Error(ERR_DROP, "Game WASM returned bad max_edicts\n");
+    }
+
+    ge->pool.edicts = Z_TagMalloc(sizeof(edict_t) * ge->pool.max_edicts, TAG_WASM);
+    memset(ge->pool.edicts, 0, sizeof(edict_t) * ge->pool.max_edicts);
+
+	wasm_function_t GetEdictSize = SV_GetWASMFunction("GetEdictSize", "()i", true);
+
+    SV_CallWASMFunction(GetEdictSize, 0, return_values);
+
+    wasm_ge.edict_size = return_values[0];
+
+    // sanitize edict_size
+    if (!wasm_ge.edict_size || wasm_ge.edict_size > (unsigned)INT_MAX / MAX_EDICTS) {
+        Com_Error(ERR_DROP, "Game WASM returned bad edict_size\n");
+    }
+
+    SV_SetWASMEntityPointers();
+}
+
+static void SV_SpawnEntitiesWasm(const char *mapname, const char *entstring, const char *spawnpoint)
+{
+    // Free all of these first so we can reclaim the space before allocations
+    if (wasm_mem.nulltexinfo) {
+        SV_FreeWASMMemory(wasm_mem.nulltexinfo);
+    }
+    if (wasm_mem.mapname) {
+        SV_FreeWASMMemory(wasm_mem.mapname);
+    }
+    if (wasm_mem.entstring) {
+        SV_FreeWASMMemory(wasm_mem.entstring);
+    }
+    if (wasm_mem.spawnpoint) {
+        SV_FreeWASMMemory(wasm_mem.spawnpoint);
+    }
+
+    // Allocate static memory that persists for an entire level.
+    wasm_mem.nulltexinfo = SV_AllocateWASMMemory(sizeof(csurface_t) * (sv.cm.cache->numtexinfo + 1));
+
+    if (!wasm_mem.nulltexinfo) {
+        Com_Error(ERR_DROP, "Couldn't allocate WASM memory\n");
+    }
+
+    wasm_mem.surfaces = wasm_mem.nulltexinfo + sizeof(csurface_t);
+
+    // copy in the BSP's surface info
+    for (int i = 0; i < sv.cm.cache->numtexinfo; i++) {
+        wasm_address_t surf_addr = wasm_mem.surfaces + (sizeof(csurface_t) * i);
+        mtexinfo_t *texinfo = sv.cm.cache->texinfo + i;
+
+        memcpy(SV_ResolveWASMAddress(surf_addr), &texinfo->c, sizeof(csurface_t));
+    }
+
+    wasm_mem.mapname = SV_AllocateWASMMemory(strlen(mapname) + 1);
+    
+    if (!wasm_mem.mapname) {
+        Com_Error(ERR_DROP, "Couldn't allocate WASM memory\n");
+    }
+
+    Q_strlcpy(SV_ResolveWASMAddress(wasm_mem.mapname), mapname, strlen(mapname) + 1);
+
+    wasm_mem.entstring = SV_AllocateWASMMemory(strlen(entstring) + 1);
+    
+    if (!wasm_mem.entstring) {
+        Com_Error(ERR_DROP, "Couldn't allocate WASM memory\n");
+    }
+
+    Q_strlcpy(SV_ResolveWASMAddress(wasm_mem.entstring), entstring, strlen(entstring) + 1);
+
+    wasm_mem.spawnpoint = SV_AllocateWASMMemory(strlen(spawnpoint) + 1);
+    
+    if (!wasm_mem.spawnpoint) {
+        Com_Error(ERR_DROP, "Couldn't allocate WASM memory\n");
+    }
+
+    Q_strlcpy(SV_ResolveWASMAddress(wasm_mem.spawnpoint), spawnpoint, strlen(spawnpoint) + 1);
+
+    uint32_t args[] = {
+        wasm_mem.mapname,
+        wasm_mem.entstring,
+        wasm_mem.spawnpoint
+    };
+
+    SV_CallWASMFunction(wasm_ge.SpawnEntities, 3, args);
+
+    post_sync_entities();
+}
+
+static void SV_WriteGameWasm(const char *filename, qboolean autosave)
+{
+    wasm_address_t filename_addr = SV_AllocateWASMMemory(strlen(filename) + 1);
+    Q_strlcpy(SV_ResolveWASMAddress(filename_addr), filename, strlen(filename) + 1);
+
+    uint32_t args[] = {
+        filename_addr,
+        autosave
+    };
+
+    SV_CallWASMFunction(wasm_ge.WriteGame, 2, args);
+    SV_FreeWASMMemory(filename_addr);
+}
+
+static void SV_ReadGameWasm(const char *filename)
+{
+    wasm_address_t filename_addr = SV_AllocateWASMMemory(strlen(filename) + 1);
+    Q_strlcpy(SV_ResolveWASMAddress(filename_addr), filename, strlen(filename) + 1);
+
+    uint32_t args[] = {
+        filename_addr
+    };
+
+    SV_CallWASMFunction(wasm_ge.ReadGame, 1, args);
+    SV_FreeWASMMemory(filename_addr);
+
+    SV_SetWASMEntityPointers();
+
+	post_sync_entities();
+}
+
+static void SV_WriteLevelWasm(const char *filename)
+{
+    wasm_address_t filename_addr = SV_AllocateWASMMemory(strlen(filename) + 1);
+    Q_strlcpy(SV_ResolveWASMAddress(filename_addr), filename, strlen(filename) + 1);
+
+    uint32_t args[] = {
+        filename_addr
+    };
+
+    SV_CallWASMFunction(wasm_ge.WriteLevel, 1, args);
+    SV_FreeWASMMemory(filename_addr);
+}
+
+static void SV_ReadLevelWasm(const char *filename)
+{
+    wasm_address_t filename_addr = SV_AllocateWASMMemory(strlen(filename) + 1);
+    Q_strlcpy(SV_ResolveWASMAddress(filename_addr), filename, strlen(filename) + 1);
+
+    uint32_t args[] = {
+        filename_addr
+    };
+
+    SV_CallWASMFunction(wasm_ge.ReadLevel, 1, args);
+    SV_FreeWASMMemory(filename_addr);
+
+	post_sync_entities();
+}
+
+static qboolean SV_ClientConnectWasm(edict_t *ent, char *userinfo)
+{
+	pre_sync_entities();
+
+    wasm_address_t userinfo_addr = SV_AllocateWASMMemory(MAX_INFO_STRING);
+    Q_strlcpy(SV_ResolveWASMAddress(userinfo_addr), userinfo, MAX_INFO_STRING);
+
+    uint32_t args[] = {
+        entity_native_to_wasm(ent),
+        userinfo_addr
+    };
+
+    SV_CallWASMFunction(wasm_ge.ClientConnect, 2, args);
+
+    Q_strlcpy(userinfo, SV_ResolveWASMAddress(userinfo_addr), MAX_INFO_STRING);
+
+    SV_FreeWASMMemory(userinfo_addr);
+
+    post_sync_entities();
+
+    return args[0];
+}
+
+static void SV_ClientBeginWasm(edict_t *ent)
+{
+	pre_sync_entities();
+
+    uint32_t args[] = {
+        entity_native_to_wasm(ent)
+    };
+    
+    SV_CallWASMFunction(wasm_ge.ClientBegin, 1, args);
+
+    post_sync_entities();
+}
+
+static qboolean SV_ClientUserinfoChangedWasm(edict_t *ent, char *userinfo)
+{
+	pre_sync_entities();
+
+    wasm_address_t userinfo_addr = SV_AllocateWASMMemory(MAX_INFO_STRING);
+    Q_strlcpy(SV_ResolveWASMAddress(userinfo_addr), userinfo, MAX_INFO_STRING);
+
+    uint32_t args[] = {
+        entity_native_to_wasm(ent),
+        userinfo_addr
+    };
+    
+    SV_CallWASMFunction(wasm_ge.ClientConnect, 2, args);
+
+    SV_FreeWASMMemory(userinfo_addr);
+
+    post_sync_entities();
+
+    return args[0];
+}
+
+static void SV_ClientDisconnectWasm(edict_t *ent)
+{
+	pre_sync_entities();
+
+    uint32_t args[] = {
+        entity_native_to_wasm(ent)
+    };
+
+    SV_CallWASMFunction(wasm_ge.ClientDisconnect, 1, args);
+
+    post_sync_entities();
+}
+
+static void SV_ClientCommandWasm(edict_t *ent)
+{
+	pre_sync_entities();
+
+    uint32_t args[] = {
+        entity_native_to_wasm(ent)
+    };
+
+    SV_CallWASMFunction(wasm_ge.ClientCommand, 1, args);
+
+    post_sync_entities();
+}
+
+static void SV_ClientThinkWasm(edict_t *ent, usercmd_t *cmd)
+{
+	pre_sync_entities();
+
+    memcpy(SV_ResolveWASMAddress(wasm_mem.usercmd), cmd, sizeof(*cmd));
+
+    uint32_t args[] = {
+        entity_native_to_wasm(ent),
+        wasm_mem.usercmd
+    };
+
+    SV_CallWASMFunction(wasm_ge.ClientThink, 2, args);
+
+    post_sync_entities();
+}
+
+static void SV_RunFrameWasm(void)
+{
+	pre_sync_entities();
+
+    SV_CallWASMFunction(wasm_ge.RunFrame, 0, NULL);
+
+    post_sync_entities();
+}
+
+static void SV_ServerCommandWasm(void)
+{
+	pre_sync_entities();
+
+    SV_CallWASMFunction(wasm_ge.ServerCommand, 0, NULL);
+
+    post_sync_entities();
+}
+
+static game_capability_t SV_QueryGameCapabilityWasm(const char *cap)
+{
+    wasm_address_t cap_addr = SV_AllocateWASMMemory(strlen(cap) + 1);
+
+    Q_strlcpy(SV_ResolveWASMAddress(cap_addr), cap, strlen(cap) + 1);
+
+    uint32_t args[] = {
+        cap_addr
+    };
+    
+    SV_CallWASMFunction(wasm_ge.QueryGameCapability, 1, args);
+
+    SV_FreeWASMMemory(cap_addr);
+
+    return (game_capability_t) args[0];
+}
+
+static wasm_game_export_t wasm_game_exports = {
+    WASM_API_VERSION,
+
+    // set up our game exports wrapper
+    SV_InitGameWasm,
+    SV_ShutdownGameWasm,
+
+    SV_SpawnEntitiesWasm,
+    
+    SV_WriteGameWasm,
+    SV_ReadGameWasm,
+    SV_WriteLevelWasm,
+    SV_ReadLevelWasm,
+    
+    SV_ClientConnectWasm,
+    SV_ClientBeginWasm,
+    SV_ClientUserinfoChangedWasm,
+    SV_ClientDisconnectWasm,
+    SV_ClientCommandWasm,
+    SV_ClientThinkWasm,
+    
+    SV_RunFrameWasm,
+
+    SV_ServerCommandWasm,
+
+    NULL,
+    0,
+    0,
+    0,
+
+    SV_QueryGameCapabilityWasm
+};
+
+/*
+===============
+SV_InitGameWasm
+
+Attempt to load a WASM game subsystem for
+a new map. Returns false if we can't.
+===============
+*/
+bool SV_InitGameWasmProgs(void)
+{
+    List_Init(&tagged_memory);
+
+    if (!_SV_InitGameWasm())
+    {
+        SV_ShutdownGameWasm();
+        return false;
+    }
+
+    ge = &wasm_game_exports.ge;
+
+    ge->Init();
+
+    ge->pool.edict_size = sizeof(edict_t);
+
+    post_sync_entities();
+
+    return true;
+}

--- a/src/server/world.c
+++ b/src/server/world.c
@@ -113,7 +113,7 @@ void SV_ClearWorld(void)
     }
 
     // make sure all entities are unlinked
-    for (i = 0; i < ge->max_edicts; i++) {
+    for (i = 0; i < ge->pool.max_edicts; i++) {
         ent = EDICT_NUM(i);
         ent->area.prev = ent->area.next = NULL;
     }
@@ -245,7 +245,7 @@ void PF_LinkEdict(edict_t *ent)
     if (ent->area.prev)
         PF_UnlinkEdict(ent);     // unlink from old position
 
-    if (ent == ge->edicts)
+    if (ent == ge->pool.edicts)
         return;        // don't add the world
 
     if (!ent->inuse) {
@@ -529,7 +529,7 @@ trace_t q_gameabi SV_Trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end,
         Com_EPrintf("%s: runaway loop avoided\n", __func__);
         memset(&trace, 0, sizeof(trace));
         trace.fraction = 1;
-        trace.ent = ge->edicts;
+        trace.ent = ge->pool.edicts;
         VectorCopy(end, trace.endpos);
         sv.tracecount = 0;
         return trace;
@@ -542,7 +542,7 @@ trace_t q_gameabi SV_Trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end,
 
     // clip to world
     CM_BoxTrace(&trace, start, end, mins, maxs, sv.cm.cache->nodes, contentmask);
-    trace.ent = ge->edicts;
+    trace.ent = ge->pool.edicts;
     if (trace.fraction == 0) {
         return trace;   // blocked by the world
     }

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -907,7 +907,7 @@ uint32_t Q_rand(void)
         x  = mt_state[i] & 0x80000000;  \
         x |= mt_state[j] & 0x7FFFFFFF;  \
         y  = x >> 1;                    \
-        y ^= 0x9908B0DF & -(x & 1);     \
+        y ^= (uint32_t) (0x9908B0DF & -((int32_t) x & 1));     \
         mt_state[i] = mt_state[k] ^ y;  \
     } while (0)
 
@@ -941,7 +941,7 @@ uint32_t Q_rand_uniform(uint32_t n)
     if (n < 2)
         return 0;
 
-    m = -n % n; // m = 2^32 mod n
+    m = (uint32_t) (-(int32_t) n % n); // m = 2^32 mod n
     do {
         r = Q_rand();
     } while (r < m);

--- a/src/windows/system.c
+++ b/src/windows/system.c
@@ -56,6 +56,7 @@ cvar_t  *sys_forcegamelib;
 #if USE_WASM
 cvar_t   *sys_wasmstacksize;
 cvar_t   *sys_wasmheapsize;
+cvar_t   *sys_nowasm;
 #endif
 
 /*
@@ -1120,6 +1121,7 @@ void Sys_Init(void)
 #if USE_WASM
     sys_wasmstacksize = Cvar_Get("sys_wasmstacksize", "8388608", CVAR_NOSET);
     sys_wasmheapsize = Cvar_Get("sys_wasmheapsize", "100663296", CVAR_NOSET);
+    sys_nowasm = Cvar_Get("sys_nowasm", "0", CVAR_NOSET);
 #endif
 
 #if USE_WINSVC

--- a/src/windows/system.c
+++ b/src/windows/system.c
@@ -53,6 +53,11 @@ cvar_t  *sys_libdir;
 cvar_t  *sys_homedir;
 cvar_t  *sys_forcegamelib;
 
+#if USE_WASM
+cvar_t   *sys_wasmstacksize;
+cvar_t   *sys_wasmheapsize;
+#endif
+
 /*
 ===============================================================================
 
@@ -1111,6 +1116,11 @@ void Sys_Init(void)
     sys_homedir = Cvar_Get("homedir", "", CVAR_NOSET);
 
     sys_forcegamelib = Cvar_Get("sys_forcegamelib", "", CVAR_NOSET);
+
+#if USE_WASM
+    sys_wasmstacksize = Cvar_Get("sys_wasmstacksize", "8388608", CVAR_NOSET);
+    sys_wasmheapsize = Cvar_Get("sys_wasmheapsize", "100663296", CVAR_NOSET);
+#endif
 
 #if USE_WINSVC
     Cmd_AddCommand("installservice", Sys_InstallService_f);

--- a/src/windows/system.c
+++ b/src/windows/system.c
@@ -1061,6 +1061,10 @@ void Sys_Sleep(int msec)
     Sleep(msec);
 }
 
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+#include <VersionHelpers.h>
+#endif
+
 /*
 ================
 Sys_Init
@@ -1068,7 +1072,6 @@ Sys_Init
 */
 void Sys_Init(void)
 {
-    OSVERSIONINFO vinfo;
 #ifndef _WIN64
     HMODULE module;
     BOOL (WINAPI * pSetProcessDEPPolicy)(DWORD);
@@ -1076,6 +1079,13 @@ void Sys_Init(void)
     cvar_t *var q_unused;
 
     // check windows version
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+    if (!IsWindowsXPOrGreater()) {
+        Sys_Error(PRODUCT " requires Windows XP or greater");
+    }
+#else
+    OSVERSIONINFO vinfo;
+
     vinfo.dwOSVersionInfoSize = sizeof(vinfo);
     if (!GetVersionEx(&vinfo)) {
         Sys_Error("Couldn't get OS info");
@@ -1086,6 +1096,7 @@ void Sys_Init(void)
     if (vinfo.dwMajorVersion < 5) {
         Sys_Error(PRODUCT " requires Windows 2000 or greater");
     }
+#endif
 
     if (!QueryPerformanceFrequency(&timer_freq))
         Sys_Error("QueryPerformanceFrequency failed");


### PR DESCRIPTION
- error.h fix for MSVC, which does not support expression statement extension
- parse.c and send.c had a (false positive) compiler error about a potential usage of null leaf1. This was resolved.
- QGL must include Windows.h on MSVC
- Several cvars were missing CVAR_ARCHIVE, making changing them not save to configuration files. If they're exposed in the in-game menus they should be archived.
- MT implementation contained error about negation of unsigned integers.
- system.c fix for MSVC > 8.1, which has deprecated/removed GetVersionEx

Most of these fixes should not affect the usual mingw/msys compilation, as they use different pathways, but this makes creating and compiling MSVC-based projects easier.

The main "meat" that isn't Windows-related is just that a bunch of cvars were not marked as archive, which forced users to directly modify config files just to permanently enable things like dynamic lighting. I think this may have been an oversight, so I'm requesting that these cvars be swapped to archive to make our lives easier.

Thank you for reading/your consideration!