### PR TITLE
quake2.exe => q2pro.exe; quake2.exe wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 /.q2pro/
 /.q2proded/
 /.baseq2/
+/.quake2/
 /q2pro*
 /q2proded*
 /baseq2/
+/quake2*
 /game*.so
 /game*.dll
 /tags

--- a/src/win-wrapper/wrapper.c
+++ b/src/win-wrapper/wrapper.c
@@ -1,0 +1,133 @@
+/* This file has been adapted from Yamagi Quake 2:
+ * https://github.com/yquake2/yquake2/blob/master/src/win-wrapper/wrapper.c
+ *
+ * Just a trivial stupid wrapper quake2.exe that starts q2pro.exe.
+ * It calls it with the whole path (assuming it's in same directory as this wrapper)
+ * and passes the commandline
+ *
+ * This should allow us to rename the real executable to q2pro.exe (to hopefully
+ * avoid trouble with whatever stupid thing interferes with mouse input once
+ * console has been opened if the games executable is called quake2.exe)
+ * while avoiding confusion for people upgrading their q2pro installation who still have
+ * shortcuts (possibly in Steam) to quake2.exe that would otherwise launch an old version.
+ *
+ * Can be built with just
+ *   $ gcc -Wall -o quake2.exe wrapper.c
+ * in our mingw build environment, will only depend on kernel32.dll and MSVCRT.DLL then,
+ * which should be available on every Windows installation.
+ * 
+ * (C) 2017 Daniel Gibson
+ * License:
+ *  This software is dual-licensed to the public domain and under the following
+ *  license: you are granted a perpetual, irrevocable license to copy, modify,
+ *  publish, and distribute this file as you see fit.
+ *  No warranty implied; use at your own risk.
+ *
+ * So you can do whatever you want with this code, including copying it
+ * (or parts of it) into your own source.
+ */
+
+#include <windows.h>
+#include <wchar.h>
+#include <stdio.h>
+
+static const WCHAR WRAPPED_EXE[] = L"q2pro.exe";
+
+// the struct and OnGetWindowByProcess taken from https://stackoverflow.com/a/17166455
+typedef struct {
+	DWORD pid;
+	HWND hwnd;
+} WINDOWPROCESSINFO;
+
+static BOOL CALLBACK OnGetWindowByProcess(HWND hwnd, LPARAM lParam)
+{
+	WINDOWPROCESSINFO *infoPtr = (WINDOWPROCESSINFO *)lParam;
+	DWORD check = 0;
+	BOOL br = TRUE;
+	GetWindowThreadProcessId(hwnd, &check);
+	if (check == infoPtr->pid)
+	{
+		infoPtr->hwnd = hwnd;
+		br = FALSE;
+	}
+	return br;
+}
+
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
+{
+	WCHAR* cmdLine = GetCommandLineW();
+	WCHAR exePath[2048];
+	WCHAR* lastBackSlash = exePath;
+	int maxLenSafe = sizeof(exePath)/sizeof(WCHAR) - wcslen(WRAPPED_EXE);
+
+	// get full path to this executable..
+	DWORD len = GetModuleFileNameW(NULL, exePath, maxLenSafe);
+	if(len <= 0 || len == maxLenSafe) {
+		// an error occured, clear exe path
+		exePath[0] = 0;
+	} else {
+		// .. cut off executable name (after last backslash in path)
+		lastBackSlash = wcsrchr(exePath, L'\\');
+		if(lastBackSlash != NULL) {
+			lastBackSlash[1] = 0;
+		} else {
+			// if there was no backslash, fall back to using only the wrapped exe name
+			// (appended to empty exePath buffer)
+			lastBackSlash = exePath;
+			lastBackSlash[0] = 0;
+		}
+	}
+
+	// .. append wrapped executable name to path ..
+	// should be safe, because maxLenSafe subtracted WRAPPED_EXE's length
+	// (and that's very conservative, we removed the original .exe name after all)
+	wcscat(lastBackSlash, WRAPPED_EXE);
+
+	// .. and start the wrapped executable
+	{
+		STARTUPINFOW si = {0};
+		PROCESS_INFORMATION pi = {0};
+		BOOL ret = FALSE;
+		si.cb = sizeof(si);
+
+		ret = CreateProcessW(exePath, cmdLine,
+		                     NULL,  // process security attributes
+		                     NULL,  // thread security attributes
+		                     FALSE, // don't inherit handles
+		                     0,     // no creation flag
+		                     NULL,  // environment block - no changes, use ours
+		                     NULL,  // don't change CWD
+		                     &si, &pi);
+
+		if(!ret)
+		{
+			fprintf(stderr, "Couldn't CreateProcess() (%ld).\n", GetLastError());
+			return 1;
+		}
+
+		Sleep(1000); // wait until q2pro should have created the window
+
+		// send window to foreground, as shown in https://stackoverflow.com/a/17166455
+
+		// first we need to get its HWND
+		WINDOWPROCESSINFO info;
+		info.pid = GetProcessId(pi.hProcess);
+		info.hwnd = 0;
+		AllowSetForegroundWindow(info.pid);
+		EnumWindows(OnGetWindowByProcess, (LPARAM)&info);
+		if (info.hwnd != 0)
+		{
+			SetForegroundWindow(info.hwnd);
+			SetActiveWindow(info.hwnd);
+		}
+
+		// wait for wrapped exe to exit
+		WaitForSingleObject(pi.hProcess, INFINITE);
+
+		// close the process and thread object handles
+		CloseHandle(pi.hProcess);
+		CloseHandle(pi.hThread);
+	}
+
+	return 0;
+}

--- a/src/windows/res/win-wrapper.rc
+++ b/src/windows/res/win-wrapper.rc
@@ -1,0 +1,57 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <windows.h>
+
+#pragma code_page(65001)
+
+#ifdef _DEBUG
+#define VER_FILEFLAGS   VS_FF_DEBUG
+#else
+#define VER_FILEFLAGS   0x0L
+#endif
+
+#ifdef _WIN64
+#define VER_FILEDESCRIPTION_STR     "Q2PRO Quake 2 client wrapper (64-bit)"
+#define VER_ORIGINALFILENAME_STR    "quake2.exe"
+#else
+#define VER_FILEDESCRIPTION_STR     "Q2PRO Quake 2 client wrapper"
+#define VER_ORIGINALFILENAME_STR    "quake2.exe"
+#endif
+
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+
+VS_VERSION_INFO VERSIONINFO
+    FILEVERSION     REVISION,0,0,0
+    PRODUCTVERSION  REVISION,0,0,0
+    FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+    FILEFLAGS       VER_FILEFLAGS
+    FILEOS          VOS_NT_WINDOWS32
+    FILETYPE        VFT_APP
+    FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "Comments", "https://github.com/skullernet/q2pro"
+            VALUE "CompanyName", "skuller.net"
+            VALUE "FileDescription", VER_FILEDESCRIPTION_STR
+            VALUE "OriginalFilename", VER_ORIGINALFILENAME_STR
+            VALUE "FileVersion", VERSION
+            VALUE "InternalName", "quake2"
+            VALUE "LegalCopyright", "Copyright © 2020 skuller.net"
+            VALUE "ProductName", "Q2PRO"
+            VALUE "ProductVersion", VERSION
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 0x4B0
+    END
+END
+
+LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
+
+100 ICON "q2pro.ico"


### PR DESCRIPTION
The Windows NVIDIA's Driver Profile patches breaks q2pro.exe when it's renamed or symbolic linked to quake2.exe. If in NVIDIA Driver the profile for Quake 2 (quake2.exe) which has Extension limit patch is disabled, the q2pro do not trigger the Fatal Error.

To fix this (#207 ) and to maintain compatibility with Steam, provide a quake2.exe wrapper that calls q2pro.exe maintaining compatibility with command line parameters.

The code was adapted from [Yamagi Quake II client](https://github.com/yquake2/yquake2/blob/master/src/win-wrapper/wrapper.c).

Take your time to look into the code.
Regards.