### PR TITLE
Borderless window (Windows)

### DIFF
--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -521,6 +521,9 @@ win_disablewinkey::
     Disables the default Windows key action to prevent it from interfering with
     game when pressed. Default is 0 (don't disable).
 
+win_noborder::
+    Hides the main window bar (borderless). Default is 0 (show window bar).
+
 win_noresize::
     Prevents the main window from resizing by dragging the border. Default is 0
     (allow resizing).

--- a/src/windows/client.c
+++ b/src/windows/client.c
@@ -41,6 +41,7 @@ static cvar_t   *win_notitle;
 static cvar_t   *win_alwaysontop;
 static cvar_t   *win_xpfix;
 static cvar_t   *win_rawmouse;
+static cvar_t   *win_noborder;
 
 static bool     Win_InitMouse(void);
 static void     Win_ClipCursor(void);
@@ -75,7 +76,9 @@ static void Win_SetPosition(void)
             after = HWND_NOTOPMOST;
         }
         style |= WS_OVERLAPPED;
-        if (win_notitle->integer) {
+        if (win_noborder->integer) {
+            style |= WS_POPUP | WS_MINIMIZEBOX | WS_MAXIMIZEBOX; // allow minimize and maximize hotkeys.
+        } else if (win_notitle->integer) {
             if (win_noresize->integer) {
                 style |= WS_DLGFRAME;
             } else {
@@ -914,6 +917,8 @@ STATIC LRESULT WINAPI Win_MainWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
         case SC_SCREENSAVE:
             return FALSE;
         case SC_MAXIMIZE:
+            if (win_noborder->integer)
+                break; // default maximize
             if (!vid_fullscreen->integer)
                 VID_ToggleFullscreen();
             return FALSE;
@@ -1025,6 +1030,8 @@ void Win_Init(void)
     win_alwaysontop->changed = win_style_changed;
     win_xpfix = Cvar_Get("win_xpfix", "0", 0);
     win_rawmouse = Cvar_Get("win_rawmouse", "1", 0);
+    win_noborder = Cvar_Get("win_noborder", "0", 0);
+    win_noborder->changed = win_style_changed;
 
     win_disablewinkey_changed(win_disablewinkey);
 


### PR DESCRIPTION
For multi-monitor users. This does not modify vid_geometry to full-screen the window. Win + Up Arrow hotkey can be used to maximize the window automatically.
Alt + Enter can still be used to toggle real full-screen.