### PR TITLE
added resume and cl_demosuspendtoggle give more control over demo recording

### DIFF
--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -992,7 +992,7 @@ cl_demowait::
 
 cl_demosuspendtoggle::
     Specifies if 'suspend' both pauses and resumes demo recording or just pauses
-    if it was recoring. Default valie is 1 (toggle between pause and resume)
+    if it was recoring. Default value is 1 (toggle between pause and resume)
 
 cl_autopause::
     Specifies if single player game or demo playback is automatically paused

--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -990,6 +990,10 @@ cl_demowait::
     Specifies if demo playback is automatically paused at the last frame in
     demo file. Default value is 0 (finish playback).
 
+cl_demosuspendtoggle::
+    Specifies if 'suspend' both pauses and resumes demo recording or just pauses
+    if it was recoring. Default valie is 1 (toggle between pause and resume)
+
 cl_autopause::
     Specifies if single player game or demo playback is automatically paused
     once client console or menu is opened. Default value is 1 (pause game).
@@ -1178,7 +1182,11 @@ stop::
     Stops demo recording and prints some statistics about recorded demo.
 
 suspend::
-    Pauses and resumes demo recording.
+    Pauses and resumes demo recording if cl_demosuspendtoggle is set to 1.
+    Just pauses demo recording if cl_demosuspendtoggle is set to 0.
+
+resume::
+    Resumes demo recording.
 
 .Demo packet sizes
 ******************

--- a/src/client/demo.c
+++ b/src/client/demo.c
@@ -27,6 +27,7 @@ static byte     demo_buffer[MAX_PACKETLEN];
 static cvar_t   *cl_demosnaps;
 static cvar_t   *cl_demomsglen;
 static cvar_t   *cl_demowait;
+static cvar_t   *cl_demosuspendtoggle;
 
 // =========================================================================
 
@@ -504,6 +505,12 @@ static void CL_Suspend_f(void)
         return;
     }
 
+    // only resume if cl_demosuspendtoggle is enabled
+    if (!cl_demosuspendtoggle->integer) {
+        Com_Printf("Demo recording is already suspended.\n");
+        return;
+    }
+
     resume_record();
 
     if (!cls.demo.recording)
@@ -513,6 +520,33 @@ static void CL_Suspend_f(void)
     Com_Printf("Resumed demo recording.\n");
 
     cls.demo.paused = false;
+
+    // clear dirty configstrings
+    memset(cl.dcs, 0, sizeof(cl.dcs));
+}
+
+static void CL_Resume_f(void)
+{
+    if (!cls.demo.recording) {
+        Com_Printf("Not recording a demo.\n");
+        return;
+    }
+
+    if (!cls.demo.paused) {
+        Com_Printf("Demo is already recording.\n");
+        return;
+    }
+
+    if (cls.demo.paused) {
+        Com_Printf("Resumed demo recording.\n");
+        cls.demo.paused = false;
+        resume_record();
+        return;
+    }
+
+    if (!cls.demo.recording)
+        // write failed
+        return;
 
     // clear dirty configstrings
     memset(cl.dcs, 0, sizeof(cl.dcs));
@@ -1232,6 +1266,7 @@ static const cmdreg_t c_demo[] = {
     { "record", CL_Record_f, CL_Demo_c },
     { "stop", CL_Stop_f },
     { "suspend", CL_Suspend_f },
+    { "resume", CL_Resume_f },
     { "seek", CL_Seek_f },
 
     { NULL }
@@ -1247,6 +1282,7 @@ void CL_InitDemos(void)
     cl_demosnaps = Cvar_Get("cl_demosnaps", "10", 0);
     cl_demomsglen = Cvar_Get("cl_demomsglen", va("%d", MAX_PACKETLEN_WRITABLE_DEFAULT), 0);
     cl_demowait = Cvar_Get("cl_demowait", "0", 0);
+    cl_demosuspendtoggle = Cvar_Get("cl_demosuspendtoggle", "1", 0);
 
     Cmd_Register(c_demo);
     List_Init(&cls.demo.snapshots);

--- a/src/client/demo.c
+++ b/src/client/demo.c
@@ -537,17 +537,16 @@ static void CL_Resume_f(void)
         return;
     }
 
-    if (cls.demo.paused) {
-        Com_Printf("Resumed demo recording.\n");
-        cls.demo.paused = false;
-        resume_record();
-        return;
-    }
+    resume_record();
 
     if (!cls.demo.recording)
         // write failed
         return;
 
+    Com_Printf("Resumed demo recording.\n");
+
+    cls.demo.paused = false;
+    
     // clear dirty configstrings
     memset(cl.dcs, 0, sizeof(cl.dcs));
 }


### PR DESCRIPTION
This change gives the user more control over pausing and resuming demo recording, by adding the `resume` command and changing the behavior of `suspend` command.

_Please be aware that my programming skills are very limited at best, there might be errors. 
But this is a very simple change, and I've tested it thoroughly locally, it works as expected.
Change wording and names of cvars and command as you see fit_ 