### PR TITLE
ExtendedGameAPI "extension" system, fetch extension by string

### DIFF
--- a/inc/server/server.h
+++ b/inc/server/server.h
@@ -42,6 +42,11 @@ void SV_SetConsoleTitle(void);
 //void SV_ConsoleOutput(const char *msg);
 void SV_RestartFilesystem(void);
 
+#ifdef GAME_API_EXTENSIONS
+void G_InitializeExtensions(void);
+
+#endif
+
 #if USE_MVD_CLIENT && USE_CLIENT
 bool MVD_GetDemoStatus(float *progress, bool *paused, int *framenum);
 #else

--- a/inc/server/server.h
+++ b/inc/server/server.h
@@ -45,6 +45,7 @@ void SV_RestartFilesystem(void);
 #ifdef GAME_API_EXTENSIONS
 void G_InitializeExtensions(void);
 
+extern int(*GE_customizeentityforclient)(edict_t *viewer, edict_t *ent, entity_state_t *state); // 0 don't send, 1 send normally
 #endif
 
 #if USE_MVD_CLIENT && USE_CLIENT

--- a/inc/shared/game.h
+++ b/inc/shared/game.h
@@ -43,8 +43,6 @@ typedef enum {
 
 // extended features
 
-#define GAME_API_EXTENSIONS
-
 // R1Q2 and Q2PRO specific
 #define GMF_CLIENTNUM               0x00000001  // game sets clientNum gclient_s field
 #define GMF_PROPERINUSE             0x00000002  // game maintains edict_s inuse field properly
@@ -264,6 +262,7 @@ typedef game_export_t *(*game_entry_t)(game_import_t *);
  */
 
 #define GAME_API_VERSION_EX     2
+#define GAME_API_EXTENSIONS
 
 typedef struct {
     int     apiversion;

--- a/src/server/entities.c
+++ b/src/server/entities.c
@@ -443,7 +443,9 @@ void SV_BuildClientFrame(client_t *client)
     frame->first_entity = svs.next_entity;
 
     for (e = 1; e < client->pool->num_edicts; e++) {
+		entity_state_t ent_state;
         ent = EDICT_POOL(client, e);
+		ent_state = ent->s; // the state we're going to network
 
         // ignore entities not in use
         if (!ent->inuse && (g_features->integer & GMF_PROPERINUSE)) {
@@ -510,9 +512,15 @@ void SV_BuildClientFrame(client_t *client)
             ent->s.number = e;
         }
 
+#ifdef GAME_API_EXTENSIONS
+		if (GE_customizeentityforclient)
+			if (!GE_customizeentityforclient(client->edict, ent, &ent_state))
+				continue;
+#endif
+
         // add it to the circular client_entities array
         state = &svs.entities[svs.next_entity % svs.num_entities];
-        MSG_PackEntity(state, &ent->s, Q2PRO_SHORTANGLES(client, e));
+        MSG_PackEntity(state, &ent_state, Q2PRO_SHORTANGLES(client, e));
 
 #if USE_FPS
         // fix old entity origins for clients not running at

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -2259,6 +2259,10 @@ void SV_Init(void)
     SV_SetConsoleTitle();
 #endif
 
+#ifdef GAME_API_EXTENSIONS
+	G_InitializeExtensions();
+#endif
+
     sv_registered = true;
 }
 


### PR DESCRIPTION
### This adds a new function to the extended game api, and bumps its version to 2.

The new functionality allows for both the engine and dll to define new entrypoints denoted with a string instead of just a relative position in the game_export/import_ex_t structs. The idea being that if other engines want to adopt ExtendedGameAPI they can do so in a more pick-and-choose manner, instead of an all-or-nothing approach if they want to implement a function that's farther down in the struct. Also gives the modder a bit more clarity on what functions are actually available, instead of having to poke around in the engine and check api versions.


### I also implemented 3 extension functions

**Client_GetProtocol** & **Client_GetVersion**
- Engine function that GameDLL can call, which returns the given client's protocol number or sub version.

**customizeentityforclient**
- GameDLL entrypoint that the engine calls, which intercepts entities before they're packed in the networking code. This is so the server can mimick client-side effects in an engine-agnostic way. Adding, removing, or modifying certain entities for specific clients can be used for team/objective markers, 3D hud effects, entity highlighting, etc.