### PR TITLE
If pressing a key during a cinematic, don't have it cause an action.

### DIFF
--- a/src/client/keys.c
+++ b/src/client/keys.c
@@ -739,13 +739,21 @@ void Key_Event(unsigned key, bool down, unsigned time)
         kb = keybindings[key];
         if (kb) {
             if (kb[0] == '+') {
-                // button commands add keynum and time as a parm
-                Q_snprintf(cmd, sizeof(cmd), "%s %i %i\n", kb, key, time);
-                Cbuf_AddText(&cmd_buffer, cmd);
-
                 // skip the rest of the cinematic
                 if (cls.state == ca_cinematic) {
                     SCR_FinishCinematic();
+                    /* Only eat the first key down event. If the key is held,
+                     * subsequent event handling will act as if the key was
+                     * "newly" pressed.
+                     * Allows some input during cinematics for the insistent
+                     * and/or impatient gamer (eg you immediately start running
+                     * by pressing the forward button during the intro). */
+                    Q_ClearBit(buttondown, key);
+                    keydown[key]--;
+                } else {
+                    // button commands add keynum and time as a parm
+                    Q_snprintf(cmd, sizeof(cmd), "%s %i %i\n", kb, key, time);
+                    Cbuf_AddText(&cmd_buffer, cmd);
                 }
             } else {
                 Cbuf_AddText(&cmd_buffer, kb);


### PR DESCRIPTION
"When you skip a cinematic, the key you used to skip it is processed as the first input in the game. For example, skip it with space, and the character will jump when map loads." (Reported here: https://github.com/NVIDIA/Q2RTX/issues/337)
The same happens in Q2PRO. E.g. Yamagi does not have this issue.

Address it by not generating a command when initially skipping cinematics due to a keypress.
(However, if the key is held down, the next repeat should generate a command;
so it's possible to eg hold the run key during a cinematic and immediately start running afterwards.)