### PR TITLE
MD5 Support

### DIFF
--- a/inc/common/hash_map.h
+++ b/inc/common/hash_map.h
@@ -1,0 +1,131 @@
+/*
+Copyright (C) 2023 Axel Gneiting
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+typedef struct hash_map_s hash_map_t;
+
+hash_map_t *HashMap_CreateImpl (
+	const uint32_t key_size, const uint32_t value_size, uint32_t (*hasher) (const void *const), qboolean (*comp) (const void *const, const void *const));
+void	 HashMap_Destroy (hash_map_t *map);
+void	 HashMap_Reserve (hash_map_t *map, int capacity);
+qboolean HashMap_InsertImpl (hash_map_t *map, const uint32_t key_size, const uint32_t value_size, const void *const key, const void *const value);
+qboolean HashMap_EraseImpl (hash_map_t *map, const uint32_t key_size, const void *const key);
+void	*HashMap_LookupImpl (hash_map_t *map, const uint32_t key_size, const void *const key);
+uint32_t HashMap_Size (hash_map_t *map);
+void	*HashMap_GetKeyImpl (hash_map_t *map, uint32_t index);
+void	*HashMap_GetValueImpl (hash_map_t *map, uint32_t index);
+
+#define HashMap_Create(key_type, value_type, hasher, comp) HashMap_CreateImpl (sizeof (key_type), sizeof (value_type), hasher, comp)
+#define HashMap_Insert(map, key, value)					   HashMap_InsertImpl (map, sizeof (*key), sizeof (*value), key, value)
+#define HashMap_Erase(map, key)							   HashMap_EraseImpl (map, sizeof (*key), key)
+#define HashMap_Lookup(type, map, key)					   ((type *)HashMap_LookupImpl (map, sizeof (*key), key))
+#define HashMap_GetKey(type, map, index)				   ((type *)HashMap_GetKeyImpl (map, index))
+#define HashMap_GetValue(type, map, index)				   ((type *)HashMap_GetValueImpl (map, index))
+
+// Murmur3 fmix32
+static inline uint32_t HashInt32 (const void *const val)
+{
+	uint32_t h = *(uint32_t *)val;
+	h ^= h >> 16;
+	h *= 0x85ebca6b;
+	h ^= h >> 13;
+	h *= 0xc2b2ae35;
+	h ^= h >> 16;
+	return h;
+}
+
+// Murmur3 fmix64
+static inline uint32_t HashInt64 (const void *const val)
+{
+	uint64_t k = *(uint64_t *)val;
+	k ^= k >> 33;
+	k *= 0xff51afd7ed558ccdull;
+	k ^= k >> 33;
+	k *= 0xc4ceb9fe1a85ec53ull;
+	k ^= k >> 33;
+	// Truncates, but all bits should be equally good
+	return k;
+}
+
+static inline uint32_t HashFloat (const void *const val)
+{
+	uint32_t float_bits;
+	memcpy (&float_bits, val, sizeof (uint32_t));
+	if (float_bits == 0x80000000)
+		float_bits = 0;
+	return HashInt32 (&float_bits);
+}
+
+static inline uint32_t HashPtr (const void *const val)
+{
+	if (sizeof (void *) == sizeof (uint64_t))
+		return HashInt64 (val);
+	return HashInt32 (val);
+}
+
+// Murmur3 hash combine
+static inline uint32_t HashCombine (uint32_t a, uint32_t b)
+{
+	a *= 0xcc9e2d51;
+	a = (a >> 17) | (a << 15);
+	a *= 0x1b873593;
+	b ^= a;
+	b = (b >> 19) | (b << 13);
+	return (b * 5) + 0xe6546b64;
+}
+
+static inline uint32_t HashVec2 (const void *const val)
+{
+	vec2_t *vec = (vec2_t *)val;
+	return HashCombine (HashFloat (&(*vec)[0]), HashFloat (&(*vec)[1]));
+}
+
+static inline uint32_t HashVec3 (const void *const val)
+{
+	vec3_t *vec = (vec3_t *)val;
+	return HashCombine (HashFloat (&(*vec)[0]), HashCombine (HashFloat (&(*vec)[1]), HashFloat (&(*vec)[2])));
+}
+
+// FNV-1a hash
+static inline uint32_t HashStr (const void *const val)
+{
+	const unsigned char	 *str = *(const unsigned char **)val;
+	static const uint32_t FNV_32_PRIME = 0x01000193;
+
+	uint32_t hval = 0;
+	while (*str)
+	{
+		hval ^= (uint32_t)*str;
+		hval *= FNV_32_PRIME;
+		++str;
+	}
+
+	return hval;
+}
+
+static inline qboolean HashStrCmp (const void *const a, const void *const b)
+{
+	const char *str_a = *(const char **)a;
+	const char *str_b = *(const char **)b;
+	return strcmp (str_a, str_b) == 0;
+}
+
+#ifdef _DEBUG
+void TestHashMap_f (void);
+#endif

--- a/inc/common/jsmn.h
+++ b/inc/common/jsmn.h
@@ -1,0 +1,468 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2010 Serge Zaitsev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef JSMN_H
+#define JSMN_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef JSMN_STATIC
+#define JSMN_API static
+#else
+#define JSMN_API extern
+#endif
+
+/**
+ * JSON type identifier. Basic types are:
+ * 	o Object
+ * 	o Array
+ * 	o String
+ * 	o Other primitive: number, boolean (true/false) or null
+ */
+typedef enum {
+  JSMN_UNDEFINED = 0,
+  JSMN_OBJECT = 1,
+  JSMN_ARRAY = 2,
+  JSMN_STRING = 3,
+  JSMN_PRIMITIVE = 4
+} jsmntype_t;
+
+enum jsmnerr {
+  /* Not enough tokens were provided */
+  JSMN_ERROR_NOMEM = -1,
+  /* Invalid character inside JSON string */
+  JSMN_ERROR_INVAL = -2,
+  /* The string is not a full JSON packet, more bytes expected */
+  JSMN_ERROR_PART = -3
+};
+
+/**
+ * JSON token description.
+ * type		type (object, array, string etc.)
+ * start	start position in JSON data string
+ * end		end position in JSON data string
+ */
+typedef struct {
+  jsmntype_t type;
+  int start;
+  int end;
+  int size;
+#ifdef JSMN_PARENT_LINKS
+  int parent;
+#endif
+} jsmntok_t;
+
+/**
+ * JSON parser. Contains an array of token blocks available. Also stores
+ * the string being parsed now and current position in that string.
+ */
+typedef struct {
+  unsigned int pos;     /* offset in the JSON string */
+  unsigned int toknext; /* next token to allocate */
+  int toksuper;         /* superior token node, e.g. parent object or array */
+} jsmn_parser;
+
+/**
+ * Create JSON parser over an array of tokens
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser);
+
+/**
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each
+ * describing
+ * a single JSON object.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens);
+
+#ifndef JSMN_HEADER
+/**
+ * Allocates a fresh unused token from the token pool.
+ */
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
+                                   const size_t num_tokens) {
+  jsmntok_t *tok;
+  if (parser->toknext >= num_tokens) {
+    return NULL;
+  }
+  tok = &tokens[parser->toknext++];
+  tok->start = tok->end = -1;
+  tok->size = 0;
+#ifdef JSMN_PARENT_LINKS
+  tok->parent = -1;
+#endif
+  return tok;
+}
+
+/**
+ * Fills token type and boundaries.
+ */
+static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
+                            const int start, const int end) {
+  token->type = type;
+  token->start = start;
+  token->end = end;
+  token->size = 0;
+}
+
+/**
+ * Fills next available token with JSON primitive.
+ */
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+                                const size_t len, jsmntok_t *tokens,
+                                const size_t num_tokens) {
+  jsmntok_t *token;
+  int start;
+
+  start = parser->pos;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    switch (js[parser->pos]) {
+#ifndef JSMN_STRICT
+    /* In strict mode primitive must be followed by "," or "}" or "]" */
+    case ':':
+#endif
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+    case ',':
+    case ']':
+    case '}':
+      goto found;
+    }
+    if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+      parser->pos = start;
+      return JSMN_ERROR_INVAL;
+    }
+  }
+#ifdef JSMN_STRICT
+  /* In strict mode primitive must be followed by a comma/object/array */
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+#endif
+
+found:
+  if (tokens == NULL) {
+    parser->pos--;
+    return 0;
+  }
+  token = jsmn_alloc_token(parser, tokens, num_tokens);
+  if (token == NULL) {
+    parser->pos = start;
+    return JSMN_ERROR_NOMEM;
+  }
+  jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+  token->parent = parser->toksuper;
+#endif
+  parser->pos--;
+  return 0;
+}
+
+/**
+ * Fills next token with JSON string.
+ */
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
+                             const size_t len, jsmntok_t *tokens,
+                             const size_t num_tokens) {
+  jsmntok_t *token;
+
+  int start = parser->pos;
+
+  parser->pos++;
+
+  /* Skip starting quote */
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c = js[parser->pos];
+
+    /* Quote: end of string */
+    if (c == '\"') {
+      if (tokens == NULL) {
+        return 0;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        parser->pos = start;
+        return JSMN_ERROR_NOMEM;
+      }
+      jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+      token->parent = parser->toksuper;
+#endif
+      return 0;
+    }
+
+    /* Backslash: Quoted symbol expected */
+    if (c == '\\' && parser->pos + 1 < len) {
+      int i;
+      parser->pos++;
+      switch (js[parser->pos]) {
+      /* Allowed escaped symbols */
+      case '\"':
+      case '/':
+      case '\\':
+      case 'b':
+      case 'f':
+      case 'r':
+      case 'n':
+      case 't':
+        break;
+      /* Allows escaped symbol \uXXXX */
+      case 'u':
+        parser->pos++;
+        for (i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0';
+             i++) {
+          /* If it isn't a hex character we have an error */
+          if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57) ||   /* 0-9 */
+                (js[parser->pos] >= 65 && js[parser->pos] <= 70) ||   /* A-F */
+                (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+            parser->pos = start;
+            return JSMN_ERROR_INVAL;
+          }
+          parser->pos++;
+        }
+        parser->pos--;
+        break;
+      /* Unexpected symbol */
+      default:
+        parser->pos = start;
+        return JSMN_ERROR_INVAL;
+      }
+    }
+  }
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+}
+
+/**
+ * Parse JSON string and fill tokens.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens) {
+  int r;
+  int i;
+  jsmntok_t *token;
+  int count = parser->toknext;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c;
+    jsmntype_t type;
+
+    c = js[parser->pos];
+    switch (c) {
+    case '{':
+    case '[':
+      count++;
+      if (tokens == NULL) {
+        break;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        return JSMN_ERROR_NOMEM;
+      }
+      if (parser->toksuper != -1) {
+        jsmntok_t *t = &tokens[parser->toksuper];
+#ifdef JSMN_STRICT
+        /* In strict mode an object or array can't become a key */
+        if (t->type == JSMN_OBJECT) {
+          return JSMN_ERROR_INVAL;
+        }
+#endif
+        t->size++;
+#ifdef JSMN_PARENT_LINKS
+        token->parent = parser->toksuper;
+#endif
+      }
+      token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+      token->start = parser->pos;
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case '}':
+    case ']':
+      if (tokens == NULL) {
+        break;
+      }
+      type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+      if (parser->toknext < 1) {
+        return JSMN_ERROR_INVAL;
+      }
+      token = &tokens[parser->toknext - 1];
+      for (;;) {
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          token->end = parser->pos + 1;
+          parser->toksuper = token->parent;
+          break;
+        }
+        if (token->parent == -1) {
+          if (token->type != type || parser->toksuper == -1) {
+            return JSMN_ERROR_INVAL;
+          }
+          break;
+        }
+        token = &tokens[token->parent];
+      }
+#else
+      for (i = parser->toknext - 1; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          parser->toksuper = -1;
+          token->end = parser->pos + 1;
+          break;
+        }
+      }
+      /* Error if unmatched closing bracket */
+      if (i == -1) {
+        return JSMN_ERROR_INVAL;
+      }
+      for (; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          parser->toksuper = i;
+          break;
+        }
+      }
+#endif
+      break;
+    case '\"':
+      r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+      break;
+    case ':':
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case ',':
+      if (tokens != NULL && parser->toksuper != -1 &&
+          tokens[parser->toksuper].type != JSMN_ARRAY &&
+          tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+        parser->toksuper = tokens[parser->toksuper].parent;
+#else
+        for (i = parser->toknext - 1; i >= 0; i--) {
+          if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+            if (tokens[i].start != -1 && tokens[i].end == -1) {
+              parser->toksuper = i;
+              break;
+            }
+          }
+        }
+#endif
+      }
+      break;
+#ifdef JSMN_STRICT
+    /* In strict mode primitives are: numbers and booleans */
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case 't':
+    case 'f':
+    case 'n':
+      /* And they must not be keys of the object */
+      if (tokens != NULL && parser->toksuper != -1) {
+        const jsmntok_t *t = &tokens[parser->toksuper];
+        if (t->type == JSMN_OBJECT ||
+            (t->type == JSMN_STRING && t->size != 0)) {
+          return JSMN_ERROR_INVAL;
+        }
+      }
+#else
+    /* In non-strict mode every unquoted value is a primitive */
+    default:
+#endif
+      r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+
+#ifdef JSMN_STRICT
+    /* Unexpected char in strict mode */
+    default:
+      return JSMN_ERROR_INVAL;
+#endif
+    }
+  }
+
+  if (tokens != NULL) {
+    for (i = parser->toknext - 1; i >= 0; i--) {
+      /* Unmatched opened object or array */
+      if (tokens[i].start != -1 && tokens[i].end == -1) {
+        return JSMN_ERROR_PART;
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Creates a new parser based over a given buffer with an array of tokens
+ * available.
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser) {
+  parser->pos = 0;
+  parser->toknext = 0;
+  parser->toksuper = -1;
+}
+
+#endif /* JSMN_HEADER */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* JSMN_H */

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -257,7 +257,8 @@ float Quat_Normalize(quat_t q);
 void Quat_MultiplyQuat (const quat_t qa, const quat_t qb, quat_t out);
 void Quat_MultiplyVector (const quat_t q, const vec3_t v, quat_t out);
 void Quat_RotatePoint (const quat_t q, const vec3_t in, vec3_t out);
-void Quat_Invert(const quat_t in, quat_t out);
+// Conjugate quaternion. Also, inverse, for unit quaternions (which MD5 quats are)
+void Quat_Conjugate(const quat_t in, quat_t out);
 #endif
 
 void AngleVectors(const vec3_t angles, vec3_t forward, vec3_t right, vec3_t up);

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -253,7 +253,7 @@ typedef vec4_t quat_t;
 
 void Quat_ComputeW(quat_t q);
 void Quat_SLerp(const quat_t qa, const quat_t qb, float backlerp, float frontlerp, quat_t out);
-void Quat_Normalize(quat_t q);
+float Quat_Normalize(quat_t q);
 void Quat_MultiplyQuat (const quat_t qa, const quat_t qb, quat_t out);
 void Quat_MultiplyVector (const quat_t q, const vec3_t v, quat_t out);
 void Quat_RotatePoint (const quat_t q, const vec3_t in, vec3_t out);

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -43,6 +43,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define q_countof(a)        (sizeof(a) / sizeof(a[0]))
 
 typedef unsigned char byte;
+typedef intptr_t ssize_t;
 typedef enum { qfalse, qtrue } qboolean;    // ABI compat only, don't use
 typedef int qhandle_t;
 
@@ -326,13 +327,9 @@ void Q_srand(uint32_t seed);
 uint32_t Q_rand(void);
 uint32_t Q_rand_uniform(uint32_t n);
 
-#define clamp(a,b,c)    ((a)<(b)?(a)=(b):(a)>(c)?(a)=(c):(a))
-#define cclamp(a,b,c)   ((b)>(c)?clamp(a,c,b):clamp(a,b,c))
-
-static inline int Q_clip(int a, int b, int c)
-{
-    return clamp(a, b, c);
-}
+#define constclamp(a,b,c)   ((a)<(b)?(b):(a)>(c)?(c):(a))
+#define clamp(a,b,c)        ((a)=constclamp((a),(b),(c)))
+#define cclamp(a,b,c)       ((b)>(c)?clamp(a,c,b):clamp(a,b,c))
 
 #ifndef max
 #define max(a,b) ((a)>(b)?(a):(b))
@@ -469,7 +466,13 @@ bool COM_IsUint(const char *s);
 bool COM_IsPath(const char *s);
 bool COM_IsWhite(const char *s);
 
-char *COM_Parse(const char **data_p);
+// extended parsing routine
+// if token_buffer is null, a temporary internal buffer will be used
+char *COM_ParseEx(const char **data_p, char *token_buffer, size_t token_buffer_size);
+
+#define COM_Parse(data_p) \
+    COM_ParseEx(data_p, NULL, 0)
+
 // data is an in/out parm, returns a parsed out token
 size_t COM_Compress(char *data);
 
@@ -482,6 +485,7 @@ char *COM_TrimSpace(char *s);
 
 // buffer safe operations
 size_t Q_strlcpy(char *dst, const char *src, size_t size);
+size_t Q_strnlcpy(char *dst, const char *src, size_t count, size_t size);
 size_t Q_strlcat(char *dst, const char *src, size_t size);
 
 #define Q_concat(dest, size, ...) \

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -238,13 +238,27 @@ typedef struct vrect_s {
      (e)[2]=(a)[2]*(c)+(b)[2]*(d))
 #define PlaneDiff(v,p)   (DotProduct(v,(p)->normal)-(p)->dist)
 
-#define Vector4Subtract(a,b,c)  ((c)[0]=(a)[0]-(b)[0],(c)[1]=(a)[1]-(b)[1],(c)[2]=(a)[2]-(b)[2],(c)[3]=(a)[3]-(b)[3])
-#define Vector4Add(a,b,c)       ((c)[0]=(a)[0]+(b)[0],(c)[1]=(a)[1]+(b)[1],(c)[2]=(a)[2]+(b)[2],(c)[3]=(a)[3]+(b)[3])
-#define Vector4Copy(a,b)        ((b)[0]=(a)[0],(b)[1]=(a)[1],(b)[2]=(a)[2],(b)[3]=(a)[3])
-#define Vector4Clear(a)         ((a)[0]=(a)[1]=(a)[2]=(a)[3]=0)
-#define Vector4Negate(a,b)      ((b)[0]=-(a)[0],(b)[1]=-(a)[1],(b)[2]=-(a)[2],(b)[3]=-(a)[3])
+#define Vector4Subtract(a,b,c)      ((c)[0]=(a)[0]-(b)[0],(c)[1]=(a)[1]-(b)[1],(c)[2]=(a)[2]-(b)[2],(c)[3]=(a)[3]-(b)[3])
+#define Vector4Add(a,b,c)           ((c)[0]=(a)[0]+(b)[0],(c)[1]=(a)[1]+(b)[1],(c)[2]=(a)[2]+(b)[2],(c)[3]=(a)[3]+(b)[3])
+#define Vector4Copy(a,b)            ((b)[0]=(a)[0],(b)[1]=(a)[1],(b)[2]=(a)[2],(b)[3]=(a)[3])
+#define Vector4Clear(a)             ((a)[0]=(a)[1]=(a)[2]=(a)[3]=0)
+#define Vector4Negate(a,b)          ((b)[0]=-(a)[0],(b)[1]=-(a)[1],(b)[2]=-(a)[2],(b)[3]=-(a)[3])
 #define Vector4Set(v, a, b, c, d)   ((v)[0]=(a),(v)[1]=(b),(v)[2]=(c),(v)[3]=(d))
-#define Vector4Compare(v1,v2)    ((v1)[0]==(v2)[0]&&(v1)[1]==(v2)[1]&&(v1)[2]==(v2)[2]&&(v1)[3]==(v2)[3])
+#define Vector4Compare(v1,v2)       ((v1)[0]==(v2)[0]&&(v1)[1]==(v2)[1]&&(v1)[2]==(v2)[2]&&(v1)[3]==(v2)[3])
+#define Dot4Product(x, y)           ((x)[0]*(y)[0]+(x)[1]*(y)[1]+(x)[2]*(y)[2]+(x)[3]*(y)[3])
+
+// quaternion routines, for MD5 skeletons
+#if USE_MD5
+typedef vec4_t quat_t;
+
+void Quat_ComputeW(quat_t q);
+void Quat_SLerp(const quat_t qa, const quat_t qb, float backlerp, float frontlerp, quat_t out);
+void Quat_Normalize(quat_t q);
+void Quat_MultiplyQuat (const quat_t qa, const quat_t qb, quat_t out);
+void Quat_MultiplyVector (const quat_t q, const vec3_t v, quat_t out);
+void Quat_RotatePoint (const quat_t q, const vec3_t in, vec3_t out);
+void Quat_Invert(const quat_t in, quat_t out);
+#endif
 
 void AngleVectors(const vec3_t angles, vec3_t forward, vec3_t right, vec3_t up);
 vec_t VectorNormalize(vec3_t v);        // returns vector length

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -466,13 +466,7 @@ bool COM_IsUint(const char *s);
 bool COM_IsPath(const char *s);
 bool COM_IsWhite(const char *s);
 
-// extended parsing routine
-// if token_buffer is null, a temporary internal buffer will be used
-char *COM_ParseEx(const char **data_p, char *token_buffer, size_t token_buffer_size);
-
-#define COM_Parse(data_p) \
-    COM_ParseEx(data_p, NULL, 0)
-
+char *COM_Parse(const char **data_p);
 // data is an in/out parm, returns a parsed out token
 size_t COM_Compress(char *data);
 

--- a/meson.build
+++ b/meson.build
@@ -453,6 +453,7 @@ config.set10('USE_DEBUG',         get_option('debug'))
 config.set10('USE_FPS',           get_option('variable-fps'))
 config.set10('USE_ICMP',          get_option('icmp-errors').require(win32 or cc.has_header('linux/errqueue.h')).allowed())
 config.set10('USE_MD3',           get_option('md3'))
+config.set10('USE_MD5',           get_option('md5'))
 config.set10('USE_PACKETDUP',     get_option('packetdup-hack'))
 config.set10('USE_TGA',           get_option('tga'))
 config.set10('USE_' + host_machine.endian().to_upper() + '_ENDIAN', true)
@@ -475,6 +476,7 @@ summary({
   'libjpeg'            : config.get('USE_JPG', 0) != 0,
   'libpng'             : config.get('USE_PNG', 0) != 0,
   'md3'                : config.get('USE_MD3', 0) != 0,
+  'md5'                : config.get('USE_MD5', 0) != 0,
   'mvd-client'         : config.get('USE_MVD_CLIENT', 0) != 0,
   'mvd-server'         : config.get('USE_MVD_SERVER', 0) != 0,
   'ogg'                : config.get('USE_OGG', 0) != 0,

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('q2pro', 'c',
   meson_version: '>= 0.59.0',
   default_options: [
     'c_std=gnu99',
-    'buildtype=debugoptimized',
+    'buildtype=debugoptimized'
   ],
 )
 
@@ -18,6 +18,7 @@ common_src = [
   'src/common/field.c',
   'src/common/fifo.c',
   'src/common/files.c',
+  'src/common/hash_map.c',
   'src/common/math.c',
   'src/common/mdfour.c',
   'src/common/msg.c',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -69,6 +69,11 @@ option('md3',
   value: true,
   description: 'MD3 models support')
 
+option('md5',
+  type: 'boolean',
+  value: true,
+  description: 'MD5 (re-release) models support')
+
 option('mvd-client',
   type: 'boolean',
   value: true,

--- a/src/client/entities.c
+++ b/src/client/entities.c
@@ -962,7 +962,7 @@ static void CL_AddPacketEntities(void)
                 i = 200;
             } else {
                 static const int bfg_lightramp[6] = {300, 400, 600, 300, 150, 75};
-                i = bfg_lightramp[Q_clip(s1->frame, 0, 5)];
+                i = bfg_lightramp[constclamp(s1->frame, 0, 5)];
             }
             V_AddLight(ent.origin, i, 0, 1, 0);
         } else if (effects & EF_TRAP) {

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -839,12 +839,12 @@ static void CL_ParseTEntPacket(void)
     }
 }
 
-static void CL_ParseMuzzleFlashPacket(int mask, bool is_short)
+static void CL_ParseMuzzleFlashPacket(int mask)
 {
     int entity, weapon;
 
     entity = MSG_ReadWord();
-    weapon = is_short ? MSG_ReadWord() : MSG_ReadByte();
+    weapon = MSG_ReadByte();
 
     if (!mask && cl.csr.extended) {
         weapon |= entity >> ENTITYNUM_BITS << 8;
@@ -1306,12 +1306,12 @@ void CL_ParseServerMessage(void)
             break;
 
         case svc_muzzleflash:
-            CL_ParseMuzzleFlashPacket(MZ_SILENCED, false);
+            CL_ParseMuzzleFlashPacket(MZ_SILENCED);
             CL_MuzzleFlash();
             break;
 
         case svc_muzzleflash2:
-            CL_ParseMuzzleFlashPacket(0, false);
+            CL_ParseMuzzleFlashPacket(0);
             CL_MuzzleFlash2();
             break;
 
@@ -1465,11 +1465,11 @@ bool CL_SeekDemoMessage(void)
             break;
 
         case svc_muzzleflash:
-            CL_ParseMuzzleFlashPacket(MZ_SILENCED, false);
+            CL_ParseMuzzleFlashPacket(MZ_SILENCED);
             break;
 
         case svc_muzzleflash2:
-            CL_ParseMuzzleFlashPacket(0, false);
+            CL_ParseMuzzleFlashPacket(0);
             break;
 
         case svc_frame:

--- a/src/client/parse.c
+++ b/src/client/parse.c
@@ -839,12 +839,12 @@ static void CL_ParseTEntPacket(void)
     }
 }
 
-static void CL_ParseMuzzleFlashPacket(int mask)
+static void CL_ParseMuzzleFlashPacket(int mask, bool is_short)
 {
     int entity, weapon;
 
     entity = MSG_ReadWord();
-    weapon = MSG_ReadByte();
+    weapon = is_short ? MSG_ReadWord() : MSG_ReadByte();
 
     if (!mask && cl.csr.extended) {
         weapon |= entity >> ENTITYNUM_BITS << 8;
@@ -1306,12 +1306,12 @@ void CL_ParseServerMessage(void)
             break;
 
         case svc_muzzleflash:
-            CL_ParseMuzzleFlashPacket(MZ_SILENCED);
+            CL_ParseMuzzleFlashPacket(MZ_SILENCED, false);
             CL_MuzzleFlash();
             break;
 
         case svc_muzzleflash2:
-            CL_ParseMuzzleFlashPacket(0);
+            CL_ParseMuzzleFlashPacket(0, false);
             CL_MuzzleFlash2();
             break;
 
@@ -1465,11 +1465,11 @@ bool CL_SeekDemoMessage(void)
             break;
 
         case svc_muzzleflash:
-            CL_ParseMuzzleFlashPacket(MZ_SILENCED);
+            CL_ParseMuzzleFlashPacket(MZ_SILENCED, false);
             break;
 
         case svc_muzzleflash2:
-            CL_ParseMuzzleFlashPacket(0);
+            CL_ParseMuzzleFlashPacket(0, false);
             break;
 
         case svc_frame:

--- a/src/common/files.c
+++ b/src/common/files.c
@@ -604,6 +604,11 @@ int FS_CreatePath(char *path)
             }
         }
     }
+    
+    // check for drive path and skip N: part
+    if (Q_charascii(*path) && path[1] == ':') {
+        ofs = path + 2;
+    }
 #endif
 
     // skip leading slash(es)

--- a/src/common/hash_map.c
+++ b/src/common/hash_map.c
@@ -1,0 +1,294 @@
+/*
+Copyright (C) 2023 Axel Gneiting
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "shared/shared.h"
+#include "common/zone.h"
+#include "common/hash_map.h"
+
+#define MIN_KEY_VALUE_STORAGE_SIZE 16
+#define MIN_HASH_SIZE			   32
+
+typedef struct hash_map_s
+{
+	uint32_t num_entries;
+	uint32_t hash_size;
+	uint32_t key_value_storage_size;
+	uint32_t key_size;
+	uint32_t value_size;
+	uint32_t (*hasher) (const void *const);
+	qboolean (*comp) (const void *const, const void *const);
+	uint32_t *hash_to_index;
+	uint32_t *index_chain;
+	void	 *keys;
+	void	 *values;
+} hash_map_t;
+
+/*
+=================
+HashMap_GetKeyImpl
+=================
+*/
+void *HashMap_GetKeyImpl (hash_map_t *map, uint32_t index)
+{
+	return (byte *)map->keys + (map->key_size * index);
+}
+
+/*
+=================
+HashMap_GetValueImpl
+=================
+*/
+void *HashMap_GetValueImpl (hash_map_t *map, uint32_t index)
+{
+	return (byte *)map->values + (map->value_size * index);
+}
+
+/*
+=================
+HashMap_Rehash
+=================
+*/
+static void HashMap_Rehash (hash_map_t *map, const uint32_t new_size)
+{
+	if (map->hash_size >= new_size)
+		return;
+	map->hash_size = new_size;
+	map->hash_to_index = Z_Realloc (map->hash_to_index, map->hash_size * sizeof (uint32_t));
+	memset (map->hash_to_index, 0xFF, map->hash_size * sizeof (uint32_t));
+	for (uint32_t i = 0; i < map->num_entries; ++i)
+	{
+		void		  *key = HashMap_GetKeyImpl (map, i);
+		const uint32_t hash = map->hasher (key);
+		const uint32_t hash_index = hash & (map->hash_size - 1);
+		map->index_chain[i] = map->hash_to_index[hash_index];
+		map->hash_to_index[hash_index] = i;
+	}
+}
+
+/*
+=================
+HashMap_ExpandKeyValueStorage
+=================
+*/
+static void HashMap_ExpandKeyValueStorage (hash_map_t *map, const uint32_t new_size)
+{
+	map->keys = Z_Realloc (map->keys, new_size * map->key_size);
+	map->values = Z_Realloc (map->values, new_size * map->value_size);
+	map->index_chain = Z_Realloc (map->index_chain, new_size * sizeof (uint32_t));
+	map->key_value_storage_size = new_size;
+}
+
+/*
+=================
+HashMap_CreateImpl
+=================
+*/
+hash_map_t *HashMap_CreateImpl (
+	const uint32_t key_size, const uint32_t value_size, uint32_t (*hasher) (const void *const), qboolean (*comp) (const void *const, const void *const))
+{
+	hash_map_t *map = Z_Mallocz (sizeof (hash_map_t));
+	map->key_size = key_size;
+	map->value_size = value_size;
+	map->hasher = hasher;
+	map->comp = comp;
+	return map;
+}
+
+/*
+=================
+HashMap_Destroy
+=================
+*/
+void HashMap_Destroy (hash_map_t *map)
+{
+	Z_Free (map->hash_to_index);
+	Z_Free (map->index_chain);
+	Z_Free (map->keys);
+	Z_Free (map->values);
+	Z_Free (map);
+}
+
+/*
+=================
+HashMap_Reserve
+=================
+*/
+void HashMap_Reserve (hash_map_t *map, int capacity)
+{
+	const uint32_t new_key_value_storage_size = Q_npot32 (capacity);
+	if (map->key_value_storage_size < new_key_value_storage_size)
+		HashMap_ExpandKeyValueStorage (map, new_key_value_storage_size);
+	const uint32_t new_hash_size = Q_npot32 (capacity + (capacity / 4));
+	if (map->hash_size < new_hash_size)
+		HashMap_Rehash (map, new_hash_size);
+}
+
+/*
+=================
+HashMap_InsertImpl
+=================
+*/
+qboolean HashMap_InsertImpl (hash_map_t *map, const uint32_t key_size, const uint32_t value_size, const void *const key, const void *const value)
+{
+	Q_assert (map->key_size == key_size);
+	Q_assert (map->value_size == value_size);
+
+	if (map->num_entries >= map->key_value_storage_size)
+		HashMap_ExpandKeyValueStorage (map, max (map->key_value_storage_size * 2, MIN_KEY_VALUE_STORAGE_SIZE));
+	if ((map->num_entries + (map->num_entries / 4)) >= map->hash_size)
+		HashMap_Rehash (map, max (map->hash_size * 2, MIN_HASH_SIZE));
+
+	const uint32_t hash = map->hasher (key);
+	const uint32_t hash_index = hash & (map->hash_size - 1);
+	{
+		uint32_t storage_index = map->hash_to_index[hash_index];
+		while (storage_index != UINT32_MAX)
+		{
+			const void *const storage_key = HashMap_GetKeyImpl (map, storage_index);
+			if (map->comp ? map->comp (key, storage_key) : (memcmp (key, storage_key, key_size) == 0))
+			{
+				memcpy (HashMap_GetValueImpl (map, storage_index), value, value_size);
+				return true;
+			}
+			storage_index = map->index_chain[storage_index];
+		}
+	}
+
+	map->index_chain[map->num_entries] = map->hash_to_index[hash_index];
+	map->hash_to_index[hash_index] = map->num_entries;
+	memcpy (HashMap_GetKeyImpl (map, map->num_entries), key, key_size);
+	memcpy (HashMap_GetValueImpl (map, map->num_entries), value, value_size);
+	++map->num_entries;
+
+	return false;
+}
+
+/*
+=================
+HashMap_EraseImpl
+=================
+*/
+qboolean HashMap_EraseImpl (hash_map_t *map, const uint32_t key_size, const void *const key)
+{
+	Q_assert (key_size == map->key_size);
+	if (map->num_entries == 0)
+		return false;
+
+	const uint32_t hash = map->hasher (key);
+	const uint32_t hash_index = hash & (map->hash_size - 1);
+	uint32_t	   storage_index = map->hash_to_index[hash_index];
+	uint32_t	  *prev_storage_index_ptr = NULL;
+	while (storage_index != UINT32_MAX)
+	{
+		const void *storage_key = HashMap_GetKeyImpl (map, storage_index);
+		if (map->comp ? map->comp (key, storage_key) : (memcmp (key, storage_key, key_size) == 0))
+		{
+			{
+				// Remove found key from index
+				if (prev_storage_index_ptr == NULL)
+					map->hash_to_index[hash_index] = map->index_chain[storage_index];
+				else
+					*prev_storage_index_ptr = map->index_chain[storage_index];
+			}
+
+			const uint32_t last_index = map->num_entries - 1;
+			const uint32_t last_hash = map->hasher (HashMap_GetKeyImpl (map, last_index));
+			const uint32_t last_hash_index = last_hash & (map->hash_size - 1);
+
+			if (storage_index == last_index)
+			{
+				--map->num_entries;
+				return true;
+			}
+
+			{
+				// Remove last key from index
+				if (map->hash_to_index[last_hash_index] == last_index)
+					map->hash_to_index[last_hash_index] = map->index_chain[last_index];
+				else
+				{
+					qboolean found = false;
+					for (uint32_t last_storage_index = map->hash_to_index[last_hash_index]; last_storage_index != UINT32_MAX;
+						 last_storage_index = map->index_chain[last_storage_index])
+					{
+						if (map->index_chain[last_storage_index] == last_index)
+						{
+							map->index_chain[last_storage_index] = map->index_chain[last_index];
+							found = true;
+							break;
+						}
+					}
+					(void)found;
+					Q_assert (found);
+				}
+			}
+
+			{
+				// Copy last key to current key position and add back to index
+				memcpy (HashMap_GetKeyImpl (map, storage_index), HashMap_GetKeyImpl (map, last_index), map->key_size);
+				memcpy (HashMap_GetValueImpl (map, storage_index), HashMap_GetValueImpl (map, last_index), map->value_size);
+				map->index_chain[storage_index] = map->hash_to_index[last_hash_index];
+				map->hash_to_index[last_hash_index] = storage_index;
+			}
+
+			--map->num_entries;
+			return true;
+		}
+		prev_storage_index_ptr = &map->index_chain[storage_index];
+		storage_index = map->index_chain[storage_index];
+	}
+	return false;
+}
+
+/*
+=================
+HashMap_LookupImpl
+=================
+*/
+void *HashMap_LookupImpl (hash_map_t *map, const uint32_t key_size, const void *const key)
+{
+	Q_assert (map->key_size == key_size);
+
+	if (map->num_entries == 0)
+		return NULL;
+
+	const uint32_t hash = map->hasher (key);
+	const uint32_t hash_index = hash & (map->hash_size - 1);
+	uint32_t	   storage_index = map->hash_to_index[hash_index];
+	while (storage_index != UINT32_MAX)
+	{
+		const void *const storage_key = HashMap_GetKeyImpl (map, storage_index);
+		if (map->comp ? map->comp (key, storage_key) : (memcmp (key, storage_key, key_size) == 0))
+			return (byte *)map->values + (storage_index * map->value_size);
+		storage_index = map->index_chain[storage_index];
+	}
+
+	return NULL;
+}
+
+/*
+=================
+HashMap_Size
+=================
+*/
+uint32_t HashMap_Size (hash_map_t *map)
+{
+	return map->num_entries;
+}

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -353,7 +353,7 @@ typedef struct
 	int num_joints;
 	md5_joint_t *base_skeleton;
 	int num_frames; // may not match model_t::numframes, but not fatal
-	md5_joint_t **skeleton_frames;
+	md5_joint_t *skeleton_frames; // [num_joints][num_frames]
 
     int num_skins;
     image_t **skins;

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -199,6 +199,10 @@ extern cvar_t *gl_modulate_entities;
 extern cvar_t *gl_doublelight_entities;
 extern cvar_t *gl_fontshadow;
 extern cvar_t *gl_shaders;
+#if USE_MD5
+extern cvar_t *gl_load_md5models;
+extern cvar_t *gl_use_md5models;
+#endif
 
 // development variables
 extern cvar_t *gl_znear;
@@ -264,15 +268,17 @@ typedef struct {
 typedef char maliasskinname_t[MAX_QPATH];
 
 typedef struct {
-    int             numverts;
-    int             numtris;
-    int             numindices;
-    int             numskins;
-    QGL_INDEX_TYPE  *indices;
-    maliasvert_t    *verts;
-    maliastc_t      *tcoords;
-    maliasskinname_t*skinnames; // for MD5
-    image_t         **skins;
+    int              numverts;
+    int              numtris;
+    int              numindices;
+    int              numskins;
+    QGL_INDEX_TYPE   *indices;
+    maliasvert_t     *verts;
+    maliastc_t       *tcoords;
+#if USE_MD5          
+    maliasskinname_t *skinnames;
+#endif               
+    image_t          **skins;
 } maliasmesh_t;
 
 typedef struct {
@@ -283,7 +289,7 @@ typedef struct {
     image_t         *image;
 } mspriteframe_t;
 
-// #if USE_MD5
+#if USE_MD5
 
 typedef vec4_t quat4_t;
 
@@ -350,7 +356,7 @@ typedef struct
     image_t **skins;
 } md5_model_t;
 
-// #endif
+#endif
 
 typedef struct {
     enum {
@@ -368,10 +374,10 @@ typedef struct {
     int numframes;
 
     maliasmesh_t *meshes; // md2 / md3
-    // #if USE_MD5
-    md5_model_t *skeleton; // md5
-    memhunk_t    skeleton_hunk;  // md5
-    // #endif
+#if USE_MD5
+    md5_model_t *skeleton;      // md5
+    memhunk_t    skeleton_hunk; // md5
+#endif
     union {
         maliasframe_t *frames;
         mspriteframe_t *spriteframes;

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -347,7 +347,7 @@ typedef struct
     QGL_INDEX_TYPE *indices;
 
 	int num_verts;
-	int num_tris;
+	int num_indices;
 	int num_weights;
 
     // animation data

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -293,6 +293,9 @@ typedef struct {
 
 typedef vec4_t quat4_t;
 
+// the total amount of joints the renderer will bother handling
+#define MAX_MD5_JOINTS  256
+
 /* Joint */
 typedef struct
 {
@@ -349,7 +352,7 @@ typedef struct
     // animation data
 	int num_joints;
 	md5_joint_t *base_skeleton;
-	int num_frames;
+	int num_frames; // may not match model_t::numframes, but not fatal
 	md5_joint_t **skeleton_frames;
 
     int num_skins;

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -261,6 +261,8 @@ typedef struct {
     vec_t   radius;
 } maliasframe_t;
 
+typedef char maliasskinname_t[MAX_QPATH];
+
 typedef struct {
     int             numverts;
     int             numtris;
@@ -269,6 +271,7 @@ typedef struct {
     QGL_INDEX_TYPE  *indices;
     maliasvert_t    *verts;
     maliastc_t      *tcoords;
+    maliasskinname_t*skinnames; // for MD5
     image_t         **skins;
 } maliasmesh_t;
 
@@ -279,6 +282,75 @@ typedef struct {
     int             origin_y;
     image_t         *image;
 } mspriteframe_t;
+
+// #if USE_MD5
+
+typedef vec4_t quat4_t;
+
+/* Joint */
+typedef struct
+{
+	int parent;
+
+	vec3_t pos;
+	quat4_t orient;
+} md5_joint_t;
+
+/* Vertex */
+typedef struct
+{
+	vec2_t st;
+    vec3_t normal;
+
+	int start; /* start weight */
+	int count; /* weight count */
+} md5_vertex_t;
+
+/* Triangle */
+typedef struct
+{
+	int index[3];
+} md5_triangle_t;
+
+/* Weight */
+typedef struct
+{
+	int joint;
+	float bias;
+
+	vec3_t pos;
+} md5_weight_t;
+
+/* Bounding box */
+typedef struct
+{
+	vec3_t min;
+	vec3_t max;
+} md5_bbox_t;
+
+/* MD5 model + animation structure */
+typedef struct
+{
+    // mesh data
+	md5_vertex_t *vertices;
+	md5_weight_t *weights;
+    QGL_INDEX_TYPE *indices;
+
+	int num_verts;
+	int num_tris;
+	int num_weights;
+
+    // animation data
+	int num_joints;
+	md5_joint_t *base_skeleton;
+	int num_frames;
+	md5_joint_t **skeleton_frames;
+
+    int num_skins;
+    image_t **skins;
+} md5_model_t;
+
+// #endif
 
 typedef struct {
     enum {
@@ -295,7 +367,11 @@ typedef struct {
     int nummeshes;
     int numframes;
 
-    maliasmesh_t *meshes;
+    maliasmesh_t *meshes; // md2 / md3
+    // #if USE_MD5
+    md5_model_t *skeleton; // md5
+    memhunk_t    skeleton_hunk;  // md5
+    // #endif
     union {
         maliasframe_t *frames;
         mspriteframe_t *spriteframes;

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -302,6 +302,7 @@ typedef struct
 
 	vec3_t pos;
 	quat_t orient;
+    float  scale;
 } md5_joint_t;
 
 /* Vertex */

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -292,8 +292,6 @@ typedef struct {
 
 #if USE_MD5
 
-typedef vec4_t quat4_t;
-
 // the total amount of joints the renderer will bother handling
 #define MAX_MD5_JOINTS  256
 
@@ -303,7 +301,7 @@ typedef struct
 	int parent;
 
 	vec3_t pos;
-	quat4_t orient;
+	quat_t orient;
 } md5_joint_t;
 
 /* Vertex */

--- a/src/refresh/main.c
+++ b/src/refresh/main.c
@@ -50,6 +50,8 @@ cvar_t *gl_modulate_entities;
 cvar_t *gl_doublelight_entities;
 cvar_t *gl_fontshadow;
 cvar_t *gl_shaders;
+cvar_t *gl_load_md5models;
+cvar_t *gl_use_md5models;
 cvar_t *gl_waterwarp;
 cvar_t *gl_swapinterval;
 
@@ -898,6 +900,10 @@ static void GL_Register(void)
     gl_doublelight_entities = Cvar_Get("gl_doublelight_entities", "1", 0);
     gl_fontshadow = Cvar_Get("gl_fontshadow", "0", 0);
     gl_shaders = Cvar_Get("gl_shaders", (gl_config.caps & QGL_CAP_SHADER) ? "1" : "0", CVAR_REFRESH);
+#if USE_MD5
+    gl_load_md5models = Cvar_Get("gl_load_md5models", "1", CVAR_REFRESH);
+    gl_use_md5models = Cvar_Get("gl_use_md5models", "1", 0);
+#endif
     gl_waterwarp = Cvar_Get("gl_waterwarp", "0", 0);
     gl_swapinterval = Cvar_Get("gl_swapinterval", "1", CVAR_ARCHIVE);
     gl_swapinterval->changed = gl_swapinterval_changed;

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -635,9 +635,7 @@ static inline void calculate_vertex_for_skeleton(const md5_vertex_t *vert, const
         VectorMA(out_position, weight->bias, wv, out_position);
             
         if (out_normal) {
-            quat_t orient_inv;
-            Quat_Conjugate(joint->orient, orient_inv);
-            Quat_RotatePoint(orient_inv, vert->normal, wv);
+            Quat_RotatePoint(joint->orient, vert->normal, wv);
             VectorScale(wv, weight->bias, wv);
             VectorAdd(out_normal, wv, out_normal);
         }

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -715,7 +715,7 @@ static inline void tess_skel_interpolate_skeleton (const md5_joint_t *skel_a, co
 {
 	for (int32_t i = 0; i < num_joints; ++i) {
 		out[i].parent = skel_a[i].parent;
-        out[i].scale = skel_a[i].scale;
+        out[i].scale = skel_b[i].scale;
 
         LerpVector2(skel_a[i].pos, skel_b[i].pos, backlerp, frontlerp, out[i].pos);
 		Quat_SLerp(skel_a[i].orient, skel_b[i].orient, backlerp, frontlerp, out[i].orient);

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -636,7 +636,7 @@ static inline void calculate_vertex_for_skeleton(const md5_vertex_t *vert, const
             
         if (out_normal) {
             quat_t orient_inv;
-            Quat_Invert(joint->orient, orient_inv);
+            Quat_Conjugate(joint->orient, orient_inv);
             Quat_RotatePoint(orient_inv, vert->normal, wv);
             VectorScale(wv, weight->bias, wv);
             VectorAdd(out_normal, wv, out_normal);

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -935,6 +935,7 @@ static void tess_lerped_shell_skel(const maliasskel_t *skel)
 #endif
 
 void Quat_rotatePoint (const quat4_t q, const vec3_t in, vec3_t out);
+void Quat_invert(const quat4_t in, quat4_t out);
 
 static void draw_alias_skeleton(const md5_model_t *model, skeltessfunc_t tessfunc)
 {
@@ -1107,7 +1108,9 @@ static void PrepareMesh_Shade (const md5_model_t *mesh, const md5_joint_t *skele
 			finalVertex[1] += (joint->pos[1] + wv[1]) * weight->bias;
 			finalVertex[2] += (joint->pos[2] + wv[2]) * weight->bias;
             
-			Quat_rotatePoint (joint->orient, mesh->vertices[i].normal, wv);
+            quat4_t orient_inv;
+            Quat_invert(joint->orient, orient_inv);
+            Quat_rotatePoint (orient_inv, mesh->vertices[i].normal, wv);
             VectorScale(wv, weight->bias, wv);
             VectorAdd(finalNormal, wv, finalNormal);
 		}
@@ -1175,8 +1178,10 @@ static void PrepareMesh_Shell (const md5_model_t *mesh, const md5_joint_t *skele
 			finalVertex[0] += (joint->pos[0] + wv[0]) * weight->bias;
 			finalVertex[1] += (joint->pos[1] + wv[1]) * weight->bias;
 			finalVertex[2] += (joint->pos[2] + wv[2]) * weight->bias;
-            
-			Quat_rotatePoint (joint->orient, mesh->vertices[i].normal, wv);
+
+            quat4_t orient_inv;
+            Quat_invert(joint->orient, orient_inv);
+            Quat_rotatePoint (orient_inv, mesh->vertices[i].normal, wv);
             VectorScale(wv, weight->bias, wv);
             VectorAdd(finalNormal, wv, finalNormal);
 		}

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -41,7 +41,7 @@ static GLfloat  shadowmatrix[16];
 #if USE_MD5
 typedef void (*skeltessfunc_t)(const md5_model_t *);
 
-static md5_joint_t  temp_skeleton[256];
+static md5_joint_t  temp_skeleton[MAX_MD5_JOINTS];
 #endif
 
 static void setup_dotshading(void)

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -499,7 +499,7 @@ static void setup_shadow(void)
     GL_MultMatrix(shadowmatrix, tmp, matrix);
 }
 
-static void draw_shadow(const maliasmesh_t *mesh)
+static inline void draw_shadow(QGL_INDEX_TYPE *indices, size_t num_indices)
 {
     if (shadowmatrix[15] < 0.5f)
         return;
@@ -521,8 +521,8 @@ static void draw_shadow(const maliasmesh_t *mesh)
     qglEnable(GL_POLYGON_OFFSET_FILL);
     qglPolygonOffset(-1.0f, -2.0f);
     GL_Color(0, 0, 0, color[3] * 0.5f);
-    qglDrawElements(GL_TRIANGLES, mesh->numindices, QGL_INDEX_ENUM,
-                    mesh->indices);
+    qglDrawElements(GL_TRIANGLES, num_indices, QGL_INDEX_ENUM,
+                    indices);
     qglDisable(GL_POLYGON_OFFSET_FILL);
 
     // once we have drawn something to stencil buffer, continue to clear it for
@@ -605,7 +605,7 @@ static void draw_alias_mesh(const maliasmesh_t *mesh, tessfunc_t tessfunc)
     }
 
     // FIXME: unlock arrays before changing matrix?
-    draw_shadow(mesh);
+    draw_shadow(mesh->indices, mesh->numindices);
 
     GL_UnlockArrays();
 }
@@ -687,10 +687,8 @@ static void draw_alias_skeleton(const md5_model_t *model, skeltessfunc_t tessfun
         GL_DrawOutlines(model->num_indices, model->indices);
     }
 
-#if 0
     // FIXME: unlock arrays before changing matrix?
-    draw_shadow(mesh);
-#endif
+    draw_shadow(model->indices, model->num_indices);
 
     GL_UnlockArrays();
 }

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -757,7 +757,7 @@ static void PrepareMesh_Plain (const md5_model_t *mesh, const md5_joint_t *skele
 
 static void tess_static_plain_skel(const md5_model_t *mesh)
 {
-    const md5_joint_t *skeleton = mesh->skeleton_frames[oldframenum % mesh->num_frames];
+    const md5_joint_t *skeleton = &mesh->skeleton_frames[(oldframenum % mesh->num_frames) * mesh->num_joints];
 
     PrepareMesh_Plain(mesh, skeleton);
 }
@@ -770,8 +770,8 @@ static void tess_lerped_plain_skel(const md5_model_t *mesh)
     };
 
 	  /* Interpolate skeletons between two frames */
-	InterpolateSkeletons (mesh->skeleton_frames[frames[0]],
-		mesh->skeleton_frames[frames[1]],
+	InterpolateSkeletons (&mesh->skeleton_frames[frames[0]* mesh->num_joints],
+		&mesh->skeleton_frames[frames[1]* mesh->num_joints],
 		mesh->num_joints,
 		frontlerp,
 		temp_skeleton);
@@ -828,7 +828,7 @@ static void PrepareMesh_Shade (const md5_model_t *mesh, const md5_joint_t *skele
 
 static void tess_static_shade_skel(const md5_model_t *mesh)
 {
-    const md5_joint_t *skeleton = mesh->skeleton_frames[oldframenum % mesh->num_frames];
+    const md5_joint_t *skeleton = &mesh->skeleton_frames[(oldframenum % mesh->num_frames) * mesh->num_joints];
 
     PrepareMesh_Shade(mesh, skeleton);
 }
@@ -841,8 +841,8 @@ static void tess_lerped_shade_skel(const md5_model_t *mesh)
     };
 
 	  /* Interpolate skeletons between two frames */
-	InterpolateSkeletons (mesh->skeleton_frames[frames[0]],
-		mesh->skeleton_frames[frames[1]],
+	InterpolateSkeletons (&mesh->skeleton_frames[frames[0] * mesh->num_joints],
+		&mesh->skeleton_frames[frames[1] * mesh->num_joints],
 		mesh->num_joints,
 		frontlerp,
 		temp_skeleton);
@@ -893,7 +893,7 @@ static void PrepareMesh_Shell (const md5_model_t *mesh, const md5_joint_t *skele
 
 static void tess_static_shell_skel(const md5_model_t *mesh)
 {
-    const md5_joint_t *skeleton = mesh->skeleton_frames[oldframenum % mesh->num_frames];
+    const md5_joint_t *skeleton = &mesh->skeleton_frames[(oldframenum % mesh->num_frames) * mesh->num_joints];
 
     PrepareMesh_Shell(mesh, skeleton);
 }
@@ -905,9 +905,9 @@ static void tess_lerped_shell_skel(const md5_model_t *mesh)
         newframenum % mesh->num_frames
     };
 
-	  /* Interpolate skeletons between two frames */
-	InterpolateSkeletons (mesh->skeleton_frames[frames[0]],
-		mesh->skeleton_frames[frames[1]],
+    /* Interpolate skeletons between two frames */
+	InterpolateSkeletons (&mesh->skeleton_frames[frames[0] * mesh->num_joints],
+		&mesh->skeleton_frames[frames[1] * mesh->num_joints],
 		mesh->num_joints,
 		frontlerp,
 		temp_skeleton);

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -625,8 +625,11 @@ static inline void calculate_vertex_for_skeleton(const md5_vertex_t *vert, const
 		const md5_weight_t *weight = &weights[vert->start + j];
 		const md5_joint_t *joint = &skeleton[weight->joint];
 
+        vec3_t local_pos;
+        VectorScale(weight->pos, joint->scale, local_pos);
+
 		vec3_t wv;
-		Quat_RotatePoint(joint->orient, weight->pos, wv);
+		Quat_RotatePoint(joint->orient, local_pos, wv);
 
         VectorAdd(joint->pos, wv, wv);
         VectorMA(out_position, weight->bias, wv, out_position);
@@ -712,6 +715,7 @@ static inline void tess_skel_interpolate_skeleton (const md5_joint_t *skel_a, co
 {
 	for (int32_t i = 0; i < num_joints; ++i) {
 		out[i].parent = skel_a[i].parent;
+        out[i].scale = skel_a[i].scale;
 
         LerpVector2(skel_a[i].pos, skel_b[i].pos, backlerp, frontlerp, out[i].pos);
 		Quat_SLerp(skel_a[i].orient, skel_b[i].orient, backlerp, frontlerp, out[i].orient);

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -425,7 +425,7 @@ static void setup_celshading(void)
     celscale = 1.0f - Distance(origin, glr.fd.vieworg) / 700.0f;
 }
 
-static void draw_celshading(const maliasmesh_t *mesh)
+static inline void draw_celshading(QGL_INDEX_TYPE *indices, size_t num_indices)
 {
     if (celscale < 0.01f || celscale > 1)
         return;
@@ -438,8 +438,8 @@ static void draw_celshading(const maliasmesh_t *mesh)
     qglPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
     qglCullFace(GL_FRONT);
     GL_Color(0, 0, 0, color[3] * celscale);
-    qglDrawElements(GL_TRIANGLES, mesh->numindices, QGL_INDEX_ENUM,
-                    mesh->indices);
+    qglDrawElements(GL_TRIANGLES, num_indices, QGL_INDEX_ENUM,
+                    indices);
     qglCullFace(GL_BACK);
     qglPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     qglLineWidth(1);
@@ -598,7 +598,7 @@ static void draw_alias_mesh(const maliasmesh_t *mesh, tessfunc_t tessfunc)
     qglDrawElements(GL_TRIANGLES, mesh->numindices, QGL_INDEX_ENUM,
                     mesh->indices);
 
-    draw_celshading(mesh);
+    draw_celshading(mesh->indices, mesh->numindices);
 
     if (gl_showtris->integer) {
         GL_DrawOutlines(mesh->numindices, mesh->indices);
@@ -662,7 +662,7 @@ static void draw_alias_skeleton(const md5_model_t *model, skeltessfunc_t tessfun
 
     (*tessfunc)(model);
 
-    c.trisDrawn += model->num_tris;
+    c.trisDrawn += model->num_indices / 3;
 
     if (shadelight) {
         GL_ArrayBits(GLA_VERTEX | GLA_TC | GLA_COLOR);
@@ -678,16 +678,16 @@ static void draw_alias_skeleton(const md5_model_t *model, skeltessfunc_t tessfun
 
     GL_LockArrays(model->num_verts);
 
-    qglDrawElements(GL_TRIANGLES, model->num_tris * 3, QGL_INDEX_ENUM,
+    qglDrawElements(GL_TRIANGLES, model->num_indices, QGL_INDEX_ENUM,
                     model->indices);
 
-#if 0
-    draw_celshading(mesh);
+    draw_celshading(model->indices, model->num_indices);
 
     if (gl_showtris->integer) {
-        GL_DrawOutlines(mesh->numindices, mesh->indices);
+        GL_DrawOutlines(model->num_indices, model->indices);
     }
 
+#if 0
     // FIXME: unlock arrays before changing matrix?
     draw_shadow(mesh);
 #endif

--- a/src/refresh/models.c
+++ b/src/refresh/models.c
@@ -1270,11 +1270,14 @@ static void MD5_ComputeNormals (md5_weight_t *weights, md5_joint_t *base, md5_ve
 		if (norm) {
             // Put the bind-pose normal into joint-local space
             // so the animated normal can be computed faster later
+            // Done by transforming the vertex normal by the inverse joint's orientation quaternion of the weight
             for ( int j = 0; j < vert[v].count; ++j ) {
 			    const md5_weight_t *weight = &weights[vert[v].start + j];
 			    const md5_joint_t *joint = &base[weight->joint];
 			    vec3_t wv;
-			    Quat_RotatePoint(joint->orient, *norm, wv);
+                quat_t orient_inv;
+                Quat_Conjugate(joint->orient, orient_inv);
+                Quat_RotatePoint(orient_inv, *norm, wv);
                 VectorMA(vert[v].normal, weight->bias, wv, vert[v].normal);
             }
         }

--- a/src/refresh/models.c
+++ b/src/refresh/models.c
@@ -1274,7 +1274,7 @@ static int MOD_LoadMD5Mesh(model_t *model, const char *file_buffer)
         }
     }
     
-    for (size_t i = 0; i < mdl->num_tris * 3; i++) {
+    for (size_t i = 0; i < mdl->num_indices; i++) {
         QGL_INDEX_TYPE *index = &index_data[i];
 
         if (*index < 0 || *index >= total_vertices) {
@@ -1294,7 +1294,7 @@ static int MOD_LoadMD5Mesh(model_t *model, const char *file_buffer)
     memcpy(mdl->weights, weight_data, sizeof(md5_weight_t) * total_weights);
 
     mdl->num_verts = total_vertices;
-    mdl->num_tris = total_indices / 3;
+    mdl->num_indices = total_indices;
     mdl->num_weights = total_weights;
 
 fail:
@@ -1731,7 +1731,7 @@ static void MOD_LoadMD5(model_t *model, const char *name)
 
     Hunk_End(&model->skeleton_hunk);
 
-    MD5_ComputeNormals(model->skeleton->weights, model->skeleton->base_skeleton, model->skeleton->vertices, model->skeleton->num_verts, model->skeleton->indices, model->skeleton->num_tris * 3);
+    MD5_ComputeNormals(model->skeleton->weights, model->skeleton->base_skeleton, model->skeleton->vertices, model->skeleton->num_verts, model->skeleton->indices, model->skeleton->num_indices);
 
     return;
 

--- a/src/refresh/models.c
+++ b/src/refresh/models.c
@@ -1231,6 +1231,9 @@ static void MD5_ComputeNormals (md5_weight_t *weights, md5_joint_t *base, md5_ve
 		CrossProduct (d1, d2, norm);
 		VectorNormalize (norm);
 
+        /* Weight vertex normals by angle
+         * see eg https://help.autodesk.com/view/MAXDEV/2023/ENU/?guid=computing_vertex_normals_by_weig
+         * for reasoning */
 		const float angle = acos (DotProduct (d1, d2));
 		VectorScale (norm, angle, norm);
 

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -227,20 +227,20 @@ void Quat_MultiplyVector (const quat_t q, const vec3_t v, quat_t out)
 	out[Z] =  (q[W] * v[Z]) + (q[X] * v[Y]) - (q[Y] * v[X]);
 }
 
-void Quat_Invert(const quat_t in, quat_t out)
+void Quat_Conjugate(const quat_t in, quat_t out)
 {
+    out[W] = in[W];
     out[X] = -in[X];
     out[Y] = -in[Y];
     out[Z] = -in[Z];
-    out[W] = in[W];
 }
 
 void Quat_RotatePoint (const quat_t q, const vec3_t in, vec3_t out)
 {
 	quat_t tmp, inv, output;
 
-    Quat_Invert(q, inv);
-	Quat_Normalize (inv);
+    // Assume q is unit quaternion
+    Quat_Conjugate(q, inv);
 	Quat_MultiplyVector (q, in, tmp);
 	Quat_MultiplyQuat (tmp, inv, output);
 

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -404,20 +404,14 @@ Parse a token out of a string.
 Handles C and C++ comments.
 ==============
 */
-char *COM_ParseEx(const char **data_p, char *token_buffer, size_t token_buffer_size)
+char *COM_Parse(const char **data_p)
 {
     int         c;
     int         len;
     const char  *data;
+    char        *s = com_token[com_tokidx];
 
-    if (token_buffer == NULL)
-    {
-        token_buffer = com_token[com_tokidx];
-        token_buffer_size = sizeof(com_token[0]);
-        com_tokidx = (com_tokidx + 1) & 3;
-    }
-
-    char *s = token_buffer;
+    com_tokidx = (com_tokidx + 1) & 3;
 
     data = *data_p;
     len = 0;

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -404,14 +404,20 @@ Parse a token out of a string.
 Handles C and C++ comments.
 ==============
 */
-char *COM_Parse(const char **data_p)
+char *COM_ParseEx(const char **data_p, char *token_buffer, size_t token_buffer_size)
 {
     int         c;
     int         len;
     const char  *data;
-    char        *s = com_token[com_tokidx];
 
-    com_tokidx = (com_tokidx + 1) & 3;
+    if (token_buffer == NULL)
+    {
+        token_buffer = com_token[com_tokidx];
+        token_buffer_size = sizeof(com_token[0]);
+        com_tokidx = (com_tokidx + 1) & 3;
+    }
+
+    char *s = token_buffer;
 
     data = *data_p;
     len = 0;
@@ -669,6 +675,26 @@ Returns length of the source string.
 size_t Q_strlcpy(char *dst, const char *src, size_t size)
 {
     size_t ret = strlen(src);
+
+    if (size) {
+        size_t len = min(ret, size - 1);
+        memcpy(dst, src, len);
+        dst[len] = 0;
+    }
+
+    return ret;
+}
+
+/*
+===============
+Q_strnlcpy
+
+Returns `count`.
+===============
+*/
+size_t Q_strnlcpy(char *dst, const char *src, size_t count, size_t size)
+{
+    size_t ret = min(count, strlen(src));
 
     if (size) {
         size_t len = min(ret, size - 1);

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -139,15 +139,15 @@ void Quat_ComputeW (quat_t q)
     }
 }
 
-#define QUAT_EPSILON 0.9999f
+#define QUAT_EPSILON 0.000001f
 
 void Quat_SLerp (const quat_t qa, const quat_t qb, float backlerp, float frontlerp, quat_t out)
 {
 	if (backlerp <= 0.0) {
-        Vector4Copy(qa, out);
+        Vector4Copy(qb, out);
 		return;
     } else if (backlerp >= 1.0) {
-        Vector4Copy(qb, out);
+        Vector4Copy(qa, out);
 		return;
 	}
 
@@ -171,13 +171,10 @@ void Quat_SLerp (const quat_t qa, const quat_t qb, float backlerp, float frontle
 		cosOmega = -cosOmega;
 	}
 
-    // we should have two unit quaternions, so dot should be <= 1.0
-	Q_assert(cosOmega < (1.0f + (1.0f - QUAT_EPSILON)));
-
 	// compute interpolation fraction
 	float k0, k1;
 
-	if (cosOmega > QUAT_EPSILON) {
+	if (1.0f - cosOmega <= QUAT_EPSILON) {
         // very close - just use linear interpolation
 		k0 = backlerp;
 		k1 = frontlerp;
@@ -199,7 +196,7 @@ void Quat_SLerp (const quat_t qa, const quat_t qb, float backlerp, float frontle
 	out[Z] = (k0 * qa[2]) + (k1 * q1z);
 }
 
-void Quat_Normalize(quat_t q)
+float Quat_Normalize(quat_t q)
 {
 	float length = sqrtf(Dot4Product(q, q));
 

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -122,6 +122,137 @@ vec_t RadiusFromBounds(const vec3_t mins, const vec3_t maxs)
     return VectorLength(corner);
 }
 
+#if USE_MD5
+#define X 0
+#define Y 1
+#define Z 2
+#define W 3
+
+void Quat_ComputeW (quat_t q)
+{
+	float t = 1.0f - (q[X] * q[X]) - (q[Y] * q[Y]) - (q[Z] * q[Z]);
+
+	if (t < 0.0f) {
+		q[W] = 0.0f;
+    } else {
+		q[W] = -sqrtf(t);
+    }
+}
+
+#define QUAT_EPSILON 0.9999f
+
+void Quat_SLerp (const quat_t qa, const quat_t qb, float backlerp, float frontlerp, quat_t out)
+{
+	if (backlerp <= 0.0) {
+        Vector4Copy(qa, out);
+		return;
+    } else if (backlerp >= 1.0) {
+        Vector4Copy(qb, out);
+		return;
+	}
+
+    // compute "cosine of angle between quaternions" using dot product
+	float cosOmega = Dot4Product (qa, qb);
+
+	/* If negative dot, use -q1.  Two quaternions q and -q
+	   represent the same rotation, but may produce
+	   different slerp.  We chose q or -q to rotate using
+	   the acute angle. */
+	float q1w = qb[W];
+	float q1x = qb[X];
+	float q1y = qb[Y];
+	float q1z = qb[Z];
+
+	if (cosOmega < 0.0f) {
+		q1w = -q1w;
+		q1x = -q1x;
+		q1y = -q1y;
+		q1z = -q1z;
+		cosOmega = -cosOmega;
+	}
+
+    // we should have two unit quaternions, so dot should be <= 1.0
+	Q_assert(cosOmega < (1.0f + (1.0f - QUAT_EPSILON)));
+
+	// compute interpolation fraction
+	float k0, k1;
+
+	if (cosOmega > QUAT_EPSILON) {
+        // very close - just use linear interpolation
+		k0 = backlerp;
+		k1 = frontlerp;
+	} else {
+        // compute the sin of the angle using the trig identity sin^2(omega) + cos^2(omega) = 1
+		float sinOmega = sqrtf(1.0f - (cosOmega * cosOmega));
+
+		// compute the angle from its sin and cosine
+		float omega = atan2f(sinOmega, cosOmega);
+		float oneOverSinOmega = 1.0f / sinOmega;
+
+		k0 = sinf(backlerp * omega) * oneOverSinOmega;
+		k1 = sinf(frontlerp * omega) * oneOverSinOmega;
+	}
+
+	out[W] = (k0 * qa[3]) + (k1 * q1w);
+	out[X] = (k0 * qa[0]) + (k1 * q1x);
+	out[Y] = (k0 * qa[1]) + (k1 * q1y);
+	out[Z] = (k0 * qa[2]) + (k1 * q1z);
+}
+
+void Quat_Normalize(quat_t q)
+{
+	float length = sqrtf(Dot4Product(q, q));
+
+	if (length) {
+		float ilength = 1 / length;
+		q[X] *= ilength;
+		q[Y] *= ilength;
+		q[Z] *= ilength;
+		q[W] *= ilength;
+	}
+
+    return length;
+}
+
+void Quat_MultiplyQuat (const quat_t qa, const quat_t qb, quat_t out)
+{
+	out[W] = (qa[W] * qb[W]) - (qa[X] * qb[X]) - (qa[Y] * qb[Y]) - (qa[Z] * qb[Z]);
+	out[X] = (qa[X] * qb[W]) + (qa[W] * qb[X]) + (qa[Y] * qb[Z]) - (qa[Z] * qb[Y]);
+	out[Y] = (qa[Y] * qb[W]) + (qa[W] * qb[Y]) + (qa[Z] * qb[X]) - (qa[X] * qb[Z]);
+	out[Z] = (qa[Z] * qb[W]) + (qa[W] * qb[Z]) + (qa[X] * qb[Y]) - (qa[Y] * qb[X]);
+}
+
+void Quat_MultiplyVector (const quat_t q, const vec3_t v, quat_t out)
+{
+	out[W] = -(q[X] * v[X]) - (q[Y] * v[Y]) - (q[Z] * v[Z]);
+	out[X] =  (q[W] * v[X]) + (q[Y] * v[Z]) - (q[Z] * v[Y]);
+	out[Y] =  (q[W] * v[Y]) + (q[Z] * v[X]) - (q[X] * v[Z]);
+	out[Z] =  (q[W] * v[Z]) + (q[X] * v[Y]) - (q[Y] * v[X]);
+}
+
+void Quat_Invert(const quat_t in, quat_t out)
+{
+    out[X] = -in[X];
+    out[Y] = -in[Y];
+    out[Z] = -in[Z];
+    out[W] = in[W];
+}
+
+void Quat_RotatePoint (const quat_t q, const vec3_t in, vec3_t out)
+{
+	quat_t tmp, inv, output;
+
+    Quat_Invert(q, inv);
+	Quat_Normalize (inv);
+	Quat_MultiplyVector (q, in, tmp);
+	Quat_MultiplyQuat (tmp, inv, output);
+
+	out[X] = output[X];
+	out[Y] = output[Y];
+	out[Z] = output[Z];
+}
+#endif
+
 //====================================================================================
 
 /*


### PR DESCRIPTION
This is a PR for MD5 support; it's based on the work res2k and I are doing in the native re-release support fork.
The code is a bit of a mix of multiple sources, but they're all GPL-compatible - mainly http://tfc.duke.free.fr/coding/md5-specs-en.html and https://github.com/Novum/vkQuake
It's 100% functional and compatible with re-release models. Let me know if any changes need to be made for inclusion in q2pro.

The one thing I wanted to do was have a unified cvar for both models, but have it only be REFRESH latched if it was 0 without having initialized any models yet. I couldn't figure out a good approach for that so I just split it into two (one to allow loading the models, and one to "use" them, so you can flip back/forth between md5 and md2 versions like re-release). 

This also supports the required `md5scale` format extension, which is used for certain models (like the Enforcer) to allow bones to "pop" off or become hidden.