### PR TITLE
enable lit liquids support

### DIFF
--- a/inc/common/bsp.h
+++ b/inc/common/bsp.h
@@ -310,9 +310,9 @@ typedef struct {
     float       fraction;
 } lightpoint_t;
 
-void BSP_LightPoint(lightpoint_t *point, const vec3_t start, const vec3_t end, mnode_t *headnode, int32_t nolm_mask);
+void BSP_LightPoint(lightpoint_t *point, const vec3_t start, const vec3_t end, mnode_t *headnode, int nolm_mask);
 void BSP_TransformedLightPoint(lightpoint_t *point, const vec3_t start, const vec3_t end,
-                               mnode_t *headnode, int32_t nolm_mask, const vec3_t origin, const vec3_t angles);
+                               mnode_t *headnode, int nolm_mask, const vec3_t origin, const vec3_t angles);
 
 lightgrid_sample_t *BSP_LookupLightgrid(lightgrid_t *grid, int32_t point[3]);
 #endif

--- a/inc/common/bsp.h
+++ b/inc/common/bsp.h
@@ -60,7 +60,9 @@ typedef struct {
 
 #define SURF_TRANS_MASK (SURF_TRANS33 | SURF_TRANS66)
 #define SURF_COLOR_MASK (SURF_TRANS_MASK | SURF_WARP)
-#define SURF_NOLM_MASK  (SURF_COLOR_MASK | SURF_FLOWING | SURF_SKY | SURF_NODRAW)
+
+#define SURF_NOLM_MASK_LIT_LIQUIDS  (SURF_SKY | SURF_NODRAW)
+#define SURF_NOLM_MASK_VANILLA      (SURF_COLOR_MASK | SURF_FLOWING | SURF_NOLM_MASK_LIT_LIQUIDS)
 
 #define DSURF_PLANEBACK     1
 
@@ -288,6 +290,8 @@ typedef struct bsp_s {
     lightgrid_t     lightgrid;
 
     bool            lm_decoupled;
+
+    int             nolm_mask;
 #endif
     bool            extended;
 
@@ -306,9 +310,9 @@ typedef struct {
     float       fraction;
 } lightpoint_t;
 
-void BSP_LightPoint(lightpoint_t *point, const vec3_t start, const vec3_t end, mnode_t *headnode);
+void BSP_LightPoint(lightpoint_t *point, const vec3_t start, const vec3_t end, mnode_t *headnode, int32_t nolm_mask);
 void BSP_TransformedLightPoint(lightpoint_t *point, const vec3_t start, const vec3_t end,
-                               mnode_t *headnode, const vec3_t origin, const vec3_t angles);
+                               mnode_t *headnode, int32_t nolm_mask, const vec3_t origin, const vec3_t angles);
 
 lightgrid_sample_t *BSP_LookupLightgrid(lightgrid_t *grid, int32_t point[3]);
 #endif

--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -1361,35 +1361,12 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
         }
     }
 
-    // check if we have lit liquids/translucents; this is a bit
-    // messy because while empty lightmap surfaces are supposed
-    // to contain lightofs -1, the GPL release of qrad3 caused
-    // them to have lightofs 0 instead, which the engine ignored
-    // anyways because it had SURF_WARP; now that we support lit
-    // liquids, we have to detect this incorrect behavior.
     bsp->nolm_mask = SURF_NOLM_MASK_VANILLA;
-    int num_lit_liquids = 0;
-    mface_t *face;
-    
-    // find at least two surfaces that contain lightmap data
-    for (i = 0, face = bsp->faces; num_lit_liquids < 2 && i < bsp->numfaces; i++, face++) {
-        if (face->texinfo->c.flags & (SURF_COLOR_MASK | SURF_FLOWING) &&
-            face->lightmap != bsp->lightmap) {
-            num_lit_liquids++;
-        }
-    }
 
-    if (num_lit_liquids == 2) {
+    // only supported in DECOUPLED_LM maps because vanilla
+    // maps have broken lightofs for liquids/alphas.
+    if (bsp->lm_decoupled) {
         bsp->nolm_mask = SURF_NOLM_MASK_LIT_LIQUIDS;
-    } else {
-        // if the map wasn't meant to have lit liquids, unset the lightmap instead of
-        // pointing to the wrong lightmap.
-        for (i = 0, face = bsp->faces; num_lit_liquids < 2 && i < bsp->numfaces; i++, face++) {
-            if (face->texinfo->c.flags & (SURF_COLOR_MASK | SURF_FLOWING) &&
-                face->lightmap == bsp->lightmap) {
-                face->lightmap = NULL;
-            }
-        }
     }
 #endif
 

--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -1381,6 +1381,15 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
 
     if (num_lit_liquids == 2) {
         bsp->nolm_mask = SURF_NOLM_MASK_LIT_LIQUIDS;
+    } else {
+        // if the map wasn't meant to have lit liquids, unset the lightmap instead of
+        // pointing to the wrong lightmap.
+        for (i = 0, face = bsp->faces; num_lit_liquids < 2 && i < bsp->numfaces; i++, face++) {
+            if (face->texinfo->c.flags & (SURF_COLOR_MASK | SURF_FLOWING) &&
+                face->lightmap == bsp->lightmap) {
+                face->lightmap = NULL;
+            }
+        }
     }
 #endif
 

--- a/src/refresh/surf.c
+++ b/src/refresh/surf.c
@@ -272,7 +272,7 @@ void GL_PushLights(mface_t *surf)
     if (!surf->lightmap) {
         return;
     }
-    if (surf->drawflags & SURF_NOLM_MASK) {
+    if (surf->drawflags & gl_static.world.cache->nolm_mask) {
         return;
     }
     if (!surf->texnum[1]) {
@@ -451,7 +451,7 @@ static void LM_RebuildSurfaces(void)
         if (!surf->lightmap) {
             continue;
         }
-        if (surf->drawflags & SURF_NOLM_MASK) {
+        if (surf->drawflags & gl_static.world.cache->nolm_mask) {
             continue;
         }
         if (!surf->texnum[1]) {
@@ -684,7 +684,7 @@ static void build_surface_light(mface_t *surf, vec_t *vbo)
     if (!surf->lightmap)
         return;
 
-    if (surf->drawflags & SURF_NOLM_MASK)
+    if (surf->drawflags & gl_static.world.cache->nolm_mask)
         return;
 
     smax = surf->lm_width;

--- a/src/refresh/surf.c
+++ b/src/refresh/surf.c
@@ -496,6 +496,17 @@ POLYGONS BUILDING
 
 static uint32_t color_for_surface(mface_t *surf)
 {
+    if (surf->lightmap && gl_shaders->integer) {
+
+        if (surf->drawflags & SURF_TRANS33)
+            return MakeColor(255, 255, 255, 85);
+
+        if (surf->drawflags & SURF_TRANS66)
+            return MakeColor(255, 255, 255, 170);
+
+        return U32_WHITE;
+    }
+
     if (surf->drawflags & SURF_TRANS33)
         return gl_static.inverse_intensity_33;
 
@@ -530,7 +541,9 @@ static void build_surface_poly(mface_t *surf, vec_t *vbo)
         if (!(surf->drawflags & SURF_TRANS_MASK)) {
             surf->statebits |= GLS_TEXTURE_REPLACE;
         }
-        if (!(surf->drawflags & SURF_COLOR_MASK) ||
+        if (surf->lightmap) {
+            surf->statebits |= GLS_INTENSITY_ENABLE; // always use intensity on lightmapped surfaces
+        } else if (!(surf->drawflags & SURF_COLOR_MASK) ||
             (!(surf->drawflags & SURF_TRANS_MASK) && strstr(texinfo->name, "lava"))) {
             surf->statebits |= GLS_INTENSITY_ENABLE;
         }

--- a/src/refresh/world.c
+++ b/src/refresh/world.c
@@ -138,7 +138,7 @@ static bool _GL_LightPoint(const vec3_t start, vec3_t color)
     end[2] = start[2] - 8192;
 
     // get base lightpoint from world
-    BSP_LightPoint(&glr.lightpoint, start, end, bsp->nodes);
+    BSP_LightPoint(&glr.lightpoint, start, end, bsp->nodes, bsp->nolm_mask);
 
     // trace to other BSP models
     for (i = 0; i < glr.fd.num_entities; i++) {
@@ -173,7 +173,7 @@ static bool _GL_LightPoint(const vec3_t start, vec3_t color)
         }
 
         BSP_TransformedLightPoint(&pt, start, end, model->headnode,
-                                  ent->origin, angles);
+                                  gl_static.world.cache->nolm_mask, ent->origin, angles);
 
         if (pt.fraction < glr.lightpoint.fraction)
             glr.lightpoint = pt;
@@ -209,7 +209,7 @@ static void GL_MarkLights_r(mnode_t *node, dlight_t *light, uint64_t lightbit)
         face = node->firstface;
         count = node->numfaces;
         while (count--) {
-            if (!(face->drawflags & SURF_NOLM_MASK)) {
+            if (!(face->drawflags & gl_static.world.cache->nolm_mask)) {
                 if (face->dlightframe != glr.dlightframe) {
                     face->dlightframe = glr.dlightframe;
                     face->dlightbits = 0;


### PR DESCRIPTION
Quake II Re-release supports what the Quake 1 community calls "lit liquids/lit water", but is really just enabling lightmaps on any surface type that is visible (in Q2 this includes warp, trans33/66, flowing, etc).

I got this working on my branch, but it currently only functions if `gl_shaders` is 1; I assume this is something that can't be worked around easily, although Quake III Arena supports it if I recall so it might be worth investigating since it has a GL 1.x-esque renderer as well.

The implementation is a bit complex because of a quirk in maps compiled for Quake II from the GPL release tools - the tools had a defect where most non-lightmapped surfaces were given a `lightofs` of `0` due to an oversight, instead of `-1`. This essentially means they are technically "lightmapped" but pointing to garbage, and nearly all third party maps made before 2021-ish will have this defect, so I have a workaround implemented here that checks if the map has multiple non-lightmapped surfaces that contain a lightofs of `0`. If we do, we assume it's a vanilla map with no lit liquids.

There is *technically* a non-zero chance that there is a BSP out there that has literally only one liquid/sky face with a lightofs of 0, in which case this code will assume it is lightmapped and is a false-positive. I don't know at the moment if this actually happens in practice, and I don't know if there's an easy workaround other than simply providing a cvar or something. It's extremely unlikely because of the way the map compiler works, and it's rare that a map includes a small enough liquid face without also having sky or a translucent surface somewhere else.

It's tempting to just enable lit liquids for only DECOUPLED_LM maps, but we already have maps in the wild that properly support lit liquids in only the vanilla lightmap lump so I don't think that's a good idea. Same as the MD5 stuff, let me know if any adjustments need to be made to style or anything for Q2PRO inclusion and I'll poke at it.