### PR TITLE
glowmap support

### DIFF
--- a/inc/common/bsp.h
+++ b/inc/common/bsp.h
@@ -82,7 +82,7 @@ typedef struct mface_s {
     int             lm_width;
     int             lm_height;
 
-    int             texnum[2];
+    int             texnum[3]; // FIXME MAX_TMUS
     int             statebits;
     int             firstvert;
     int             light_s, light_t;

--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -159,7 +159,7 @@ typedef enum {
     IF_TURBULENT    = BIT(5),
     IF_REPEAT       = BIT(6),
     IF_NEAREST      = BIT(7),
-    IF_OPAQUE       = BIT(8),
+    IF_OPAQUE       = BIT(8)
 } imageflags_t;
 
 typedef enum {

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -482,6 +482,7 @@ char *COM_TrimSpace(char *s);
 
 // buffer safe operations
 size_t Q_strlcpy(char *dst, const char *src, size_t size);
+size_t Q_strnlcpy(char *dst, const char *src, size_t count, size_t size);
 size_t Q_strlcat(char *dst, const char *src, size_t size);
 
 #define Q_concat(dest, size, ...) \

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -45,12 +45,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define QGL_INDEX_ENUM  GL_UNSIGNED_INT
 #endif
 
-#define MAX_TMUS        2
+#define MAX_TMUS        3
 
 #define TAB_SIN(x) gl_static.sintab[(x) & 255]
 #define TAB_COS(x) gl_static.sintab[((x) + 64) & 255]
 
-#define MAX_PROGRAMS    64
+#define MAX_PROGRAMS    128
 #define NUM_TEXNUMS     7
 
 typedef struct {
@@ -363,16 +363,17 @@ typedef enum {
     GLS_LIGHTMAP_ENABLE     = BIT(9),
     GLS_WARP_ENABLE         = BIT(10),
     GLS_INTENSITY_ENABLE    = BIT(11),
-    GLS_SHADE_SMOOTH        = BIT(12),
-    GLS_SCROLL_X            = BIT(13),
-    GLS_SCROLL_Y            = BIT(14),
-    GLS_SCROLL_FLIP         = BIT(15),
-    GLS_SCROLL_SLOW         = BIT(16),
+    GLS_GLOWMAP_ENABLE      = BIT(12),
+    GLS_SHADE_SMOOTH        = BIT(13),
+    GLS_SCROLL_X            = BIT(14),
+    GLS_SCROLL_Y            = BIT(15),
+    GLS_SCROLL_FLIP         = BIT(16),
+    GLS_SCROLL_SLOW         = BIT(17),
 
     GLS_BLEND_MASK  = GLS_BLEND_BLEND | GLS_BLEND_ADD | GLS_BLEND_MODULATE,
     GLS_COMMON_MASK = GLS_DEPTHMASK_FALSE | GLS_DEPTHTEST_DISABLE | GLS_CULL_DISABLE | GLS_BLEND_MASK,
     GLS_SHADER_MASK = GLS_ALPHATEST_ENABLE | GLS_TEXTURE_REPLACE | GLS_SCROLL_ENABLE |
-        GLS_LIGHTMAP_ENABLE | GLS_WARP_ENABLE | GLS_INTENSITY_ENABLE,
+        GLS_LIGHTMAP_ENABLE | GLS_WARP_ENABLE | GLS_INTENSITY_ENABLE | GLS_GLOWMAP_ENABLE,
     GLS_SCROLL_MASK = GLS_SCROLL_ENABLE | GLS_SCROLL_X | GLS_SCROLL_Y | GLS_SCROLL_FLIP | GLS_SCROLL_SLOW,
 } glStateBits_t;
 

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -1790,9 +1790,6 @@ static image_t *find_or_load_image(const char *name, size_t len,
 
     List_Append(&r_imageHash[hash], &image->entry);
 
-    // upload the image
-    IMG_Load(image, pic);
-
     // check for glow maps
     if (r_glowmaps->integer && (type == IT_SKIN || type == IT_WALL)) {
         byte *glow_pic = NULL;
@@ -1842,6 +1839,9 @@ static image_t *find_or_load_image(const char *name, size_t len,
 
         Z_Free(glow_pic);
     }
+
+    // upload the image
+    IMG_Load(image, pic);
 
     // don't need pics in memory after GL upload
     Z_Free(pic);

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -1808,8 +1808,8 @@ static image_t *find_or_load_image(const char *name, size_t len,
         if (!(ret < 0)) {
             // post-process data;
             // - model glowmaps should be premultiplied
-            // - wal glowmaps are only alpha, so we have to put
-            //   back in the diffuse map data then premultiply
+            // - wal glowmaps just use the alpha, so the RGB channels are ignored
+            //   except in the legacy path.
             if (type == IT_SKIN) {
                 int i = 0;
                 int s = temporary.upload_width * temporary.upload_height;

--- a/src/refresh/images.h
+++ b/src/refresh/images.h
@@ -64,7 +64,7 @@ typedef struct image_s {
     int16_t         width, height; // source image
     int16_t         upload_width, upload_height; // after power of two and picmip
     int             registration_sequence; // 0 = free
-    unsigned        texnum; // gl texture binding
+    unsigned        texnum, glow_texnum; // gl texture binding
     float           sl, sh, tl, th;
     float           aspect;
 } image_t;
@@ -76,7 +76,8 @@ extern int      r_numImages;
 
 extern int registration_sequence;
 
-#define R_NOTEXTURE &r_images[0]
+#define R_NOTEXTURE    &r_images[0]
+#define R_BLACKTEXTURE &r_images[5]
 
 extern uint32_t d_8to24table[256];
 
@@ -90,6 +91,7 @@ void IMG_GetPalette(void);
 image_t *IMG_ForHandle(qhandle_t h);
 
 void IMG_Unload(image_t *image);
+void IMG_LoadRaw(image_t *image, byte *pic, int width, int height);
 void IMG_Load(image_t *image, byte *pic);
 
 struct screenshot_s;

--- a/src/refresh/legacy.c
+++ b/src/refresh/legacy.c
@@ -65,6 +65,16 @@ static void legacy_state_bits(GLbitfield bits)
         }
     }
 
+    if (diff & GLS_GLOWMAP_ENABLE) {
+        GL_ActiveTexture(2);
+        if (bits & GLS_GLOWMAP_ENABLE) {
+            qglEnable(GL_TEXTURE_2D);
+            qglTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_ADD);
+        } else {
+            qglDisable(GL_TEXTURE_2D);
+        }
+    }
+
     if ((diff & GLS_WARP_ENABLE) && gl_static.programs[0]) {
         if (bits & GLS_WARP_ENABLE) {
             vec4_t param = { glr.fd.time, glr.fd.time };
@@ -105,6 +115,13 @@ static void legacy_array_bits(GLbitfield bits)
         } else {
             qglDisableClientState(GL_TEXTURE_COORD_ARRAY);
         }
+
+        GL_ClientActiveTexture(2);
+        if (bits & GLA_TC) {
+            qglEnableClientState(GL_TEXTURE_COORD_ARRAY);
+        } else {
+            qglDisableClientState(GL_TEXTURE_COORD_ARRAY);
+        }
     }
 
     if (diff & GLA_LMTC) {
@@ -133,6 +150,9 @@ static void legacy_vertex_pointer(GLint size, GLsizei stride, const GLfloat *poi
 static void legacy_tex_coord_pointer(GLint size, GLsizei stride, const GLfloat *pointer)
 {
     GL_ClientActiveTexture(0);
+    qglTexCoordPointer(size, GL_FLOAT, sizeof(GLfloat) * stride, pointer);
+
+    GL_ClientActiveTexture(2);
     qglTexCoordPointer(size, GL_FLOAT, sizeof(GLfloat) * stride, pointer);
 }
 

--- a/src/refresh/mesh.c
+++ b/src/refresh/mesh.c
@@ -529,28 +529,43 @@ static void draw_shadow(const maliasmesh_t *mesh)
     }
 }
 
-static int texnum_for_mesh(const maliasmesh_t *mesh)
+static inline void texnums_for_model(int num_skins, image_t **skins, int *diffuse_skin, int *glow_skin)
 {
     const entity_t *ent = glr.ent;
 
-    if (ent->flags & RF_SHELL_MASK)
-        return TEXNUM_WHITE;
-
-    if (ent->skin)
-        return IMG_ForHandle(ent->skin)->texnum;
-
-    if (!mesh->numskins)
-        return TEXNUM_DEFAULT;
-
-    if (ent->skinnum < 0 || ent->skinnum >= mesh->numskins) {
-        Com_DPrintf("%s: no such skin: %d\n", "GL_DrawAliasModel", ent->skinnum);
-        return mesh->skins[0]->texnum;
+    if (ent->flags & RF_SHELL_MASK) {
+        *diffuse_skin = TEXNUM_WHITE;
+        *glow_skin = TEXNUM_BLACK;
+        return;
     }
 
-    if (mesh->skins[ent->skinnum]->texnum == TEXNUM_DEFAULT)
-        return mesh->skins[0]->texnum;
+    if (ent->skin) {
+        *diffuse_skin = IMG_ForHandle(ent->skin)->texnum;
+        *glow_skin = TEXNUM_BLACK;
+        return;
+    }
 
-    return mesh->skins[ent->skinnum]->texnum;
+    if (!num_skins) {
+        *diffuse_skin = TEXNUM_DEFAULT;
+        *glow_skin = TEXNUM_BLACK;
+        return;
+    }
+
+    if (ent->skinnum < 0 || ent->skinnum >= num_skins) {
+        Com_DPrintf("%s: no such skin: %d\n", "GL_DrawAliasModel", ent->skinnum);
+        *diffuse_skin = skins[0]->texnum;
+        *glow_skin = skins[0]->glow_texnum ? skins[0]->glow_texnum : TEXNUM_BLACK;
+        return;
+    }
+
+    if (skins[ent->skinnum]->texnum == TEXNUM_DEFAULT) {
+        *diffuse_skin = skins[0]->texnum;
+        *glow_skin = skins[0]->glow_texnum ? skins[0]->glow_texnum : TEXNUM_BLACK;
+        return;
+    }
+    
+    *diffuse_skin = skins[ent->skinnum]->texnum;
+    *glow_skin = skins[ent->skinnum]->glow_texnum ? skins[ent->skinnum]->glow_texnum : TEXNUM_BLACK;
 }
 
 static void draw_alias_mesh(const maliasmesh_t *mesh)
@@ -569,9 +584,16 @@ static void draw_alias_mesh(const maliasmesh_t *mesh)
     if ((glr.ent->flags & (RF_TRANSLUCENT | RF_WEAPONMODEL)) == RF_TRANSLUCENT)
         state |= GLS_DEPTHMASK_FALSE;
 
-    GL_StateBits(state);
+    int diffuse, glow;
+    texnums_for_model(mesh->numskins, mesh->skins, &diffuse, &glow);
+    GL_BindTexture(0, diffuse);
 
-    GL_BindTexture(0, texnum_for_mesh(mesh));
+    if (glow != TEXNUM_BLACK) {
+        state |= GLS_GLOWMAP_ENABLE;
+        GL_BindTexture(2, glow);
+    }
+
+    GL_StateBits(state);
 
     (*tessfunc)(mesh);
     c.trisDrawn += mesh->numtris;

--- a/src/refresh/models.c
+++ b/src/refresh/models.c
@@ -417,6 +417,7 @@ static int MOD_LoadMD2(model_t *model, const void *rawdata, size_t length)
         }
         FS_NormalizePath(skinname);
         mesh->skins[i] = IMG_Find(skinname, IT_SKIN, IF_NONE);
+
         src_skin += MD2_MAX_SKINNAME;
     }
 

--- a/src/refresh/shader.c
+++ b/src/refresh/shader.c
@@ -142,11 +142,7 @@ static void write_fragment_shader(char *buf, GLbitfield bits)
 
         if (bits & GLS_GLOWMAP_ENABLE) {
             GLSL(vec4 glowmap = texture(u_glowmap, tc);)
-            if (bits & GLS_INTENSITY_ENABLE) {
-                GLSL(diffuse.rgb += glowmap.rgb * u_intensity;)
-            } else {
-                GLSL(diffuse.rgb += glowmap.rgb;)
-            }
+            GLSL(diffuse.rgb += glowmap.rgb;)
         }
 
         GLSL(o_color = diffuse;)

--- a/src/refresh/shader.c
+++ b/src/refresh/shader.c
@@ -142,7 +142,11 @@ static void write_fragment_shader(char *buf, GLbitfield bits)
 
         if (bits & GLS_GLOWMAP_ENABLE) {
             GLSL(vec4 glowmap = texture(u_glowmap, tc);)
-            GLSL(diffuse.rgb += glowmap.rgb;)
+            if (bits & GLS_INTENSITY_ENABLE) {
+                GLSL(diffuse.rgb += glowmap.rgb * u_intensity;)
+            } else {
+                GLSL(diffuse.rgb += glowmap.rgb;)
+            }
         }
 
         GLSL(o_color = diffuse;)

--- a/src/refresh/shader.c
+++ b/src/refresh/shader.c
@@ -131,6 +131,15 @@ static void write_fragment_shader(char *buf, GLbitfield bits)
 
         if (bits & GLS_LIGHTMAP_ENABLE) {
             GLSL(vec4 lightmap = texture(u_lightmap, v_lmtc);)
+
+            if (bits & GLS_GLOWMAP_ENABLE) {
+                GLSL(vec4 glowmap = texture(u_glowmap, tc);)
+                // this doesn't match Kex exactly, but it's close enough
+                // and IMO looks better on lava especially - lava doesn't
+                // get over-saturated to red any more.
+                GLSL(lightmap.rgb = mix(lightmap.rgb, vec3(1.0f), glowmap.a);)
+            }
+
             GLSL(diffuse.rgb *= (lightmap.rgb + u_add) * u_modulate;)
         }
 
@@ -140,7 +149,7 @@ static void write_fragment_shader(char *buf, GLbitfield bits)
         if (!(bits & GLS_TEXTURE_REPLACE))
             GLSL(diffuse *= v_color;)
 
-        if (bits & GLS_GLOWMAP_ENABLE) {
+        if (!(bits & GLS_LIGHTMAP_ENABLE) && (bits & GLS_GLOWMAP_ENABLE)) {
             GLSL(vec4 glowmap = texture(u_glowmap, tc);)
             if (bits & GLS_INTENSITY_ENABLE) {
                 GLSL(diffuse.rgb += glowmap.rgb * u_intensity;)

--- a/src/refresh/surf.c
+++ b/src/refresh/surf.c
@@ -521,6 +521,7 @@ static void build_surface_poly(mface_t *surf, vec_t *vbo)
 
     surf->texnum[0] = texinfo->image->texnum;
     surf->texnum[1] = 0;
+    surf->texnum[2] = texinfo->image->glow_texnum;
 
     color = color_for_surface(surf);
 

--- a/src/refresh/tess.c
+++ b/src/refresh/tess.c
@@ -288,6 +288,10 @@ void GL_Flush3D(void)
         }
     }
 
+    if (tess.texnum[2]) {
+        state |= GLS_GLOWMAP_ENABLE;
+    }
+
     if (!(state & GLS_TEXTURE_REPLACE)) {
         array |= GLA_COLOR;
     }
@@ -298,6 +302,9 @@ void GL_Flush3D(void)
     GL_BindTexture(0, tess.texnum[0]);
     if (q_likely(tess.texnum[1])) {
         GL_BindTexture(1, tess.texnum[1]);
+    }
+    if (tess.texnum[2]) {
+        GL_BindTexture(2, tess.texnum[2]);
     }
 
     if (gl_static.world.vertices) {
@@ -316,7 +323,7 @@ void GL_Flush3D(void)
 
     c.batchesDrawn++;
 
-    tess.texnum[0] = tess.texnum[1] = 0;
+    tess.texnum[0] = tess.texnum[1] = tess.texnum[2] = 0;
     tess.numindices = 0;
     tess.numverts = 0;
     tess.flags = 0;
@@ -340,7 +347,7 @@ static int GL_CopyVerts(mface_t *surf)
     return firstvert;
 }
 
-static int GL_TextureAnimation(mtexinfo_t *tex)
+static void GL_TextureAnimation(mtexinfo_t *tex, int *diffuse, int *glow)
 {
     if (q_unlikely(tex->next)) {
         unsigned c = (unsigned)glr.ent->frame % tex->numframes;
@@ -350,27 +357,29 @@ static int GL_TextureAnimation(mtexinfo_t *tex)
             c--;
         }
     }
-
-    return tex->image->texnum;
+    
+    *diffuse = tex->image->texnum;
+    *glow = tex->image->glow_texnum;
 }
 
 void GL_DrawFace(mface_t *surf)
 {
     int numtris = surf->numsurfedges - 2;
     int numindices = numtris * 3;
-    GLuint texnum[2];
+    GLuint texnum[MAX_TMUS];
     QGL_INDEX_TYPE *dst_indices;
     int i, j;
 
     if (q_unlikely(gl_lightmap->integer && surf->texnum[1])) {
-        texnum[0] = TEXNUM_WHITE;
+        texnum[0] = texnum[2] = TEXNUM_WHITE;
     } else {
-        texnum[0] = GL_TextureAnimation(surf->texinfo);
+        GL_TextureAnimation(surf->texinfo, &texnum[0], &texnum[2]);
     }
     texnum[1] = surf->texnum[1];
 
     if (tess.texnum[0] != texnum[0] ||
         tess.texnum[1] != texnum[1] ||
+        tess.texnum[2] != texnum[2] ||
         tess.flags != surf->statebits ||
         tess.numindices + numindices > TESS_MAX_INDICES) {
         GL_Flush3D();
@@ -378,6 +387,7 @@ void GL_DrawFace(mface_t *surf)
 
     tess.texnum[0] = texnum[0];
     tess.texnum[1] = texnum[1];
+    tess.texnum[2] = texnum[2];
     tess.flags = surf->statebits;
 
     if (q_unlikely(gl_static.world.vertices)) {
@@ -453,7 +463,7 @@ void GL_AddSolidFace(mface_t *face)
 {
     unsigned hash;
 
-    hash = face->texnum[0] ^ face->texnum[1] ^ face->statebits;
+    hash = face->texnum[0] ^ face->texnum[1] ^ face->texnum[2] ^ face->statebits;
     hash ^= hash >> FACE_HASH_BITS;
     hash ^= hash >> (FACE_HASH_BITS * 2);
     hash &= FACE_HASH_MASK;

--- a/src/refresh/tess.c
+++ b/src/refresh/tess.c
@@ -288,7 +288,7 @@ void GL_Flush3D(void)
         }
     }
 
-    if (tess.texnum[2]) {
+    if (tess.texnum[2] && !gl_lightmap->integer) {
         state |= GLS_GLOWMAP_ENABLE;
     }
 

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -681,6 +681,26 @@ size_t Q_strlcpy(char *dst, const char *src, size_t size)
 
 /*
 ===============
+Q_strnlcpy
+
+Returns `count`.
+===============
+*/
+size_t Q_strnlcpy(char *dst, const char *src, size_t count, size_t size)
+{
+    size_t ret = min(count, strlen(src));
+
+    if (size) {
+        size_t len = min(ret, size - 1);
+        memcpy(dst, src, len);
+        dst[len] = 0;
+    }
+
+    return ret;
+}
+
+/*
+===============
 Q_strlcat
 
 Returns length of the source and destinations strings combined.


### PR DESCRIPTION
This PR adds glowmap support from re-release game files. These are simple emissive textures that are added on top of the diffuse maps.

* this implementation supports glowmaps on player models and RF_CUSTOMSKINs as well (re-release lacks this functionality)
* supports both gl_shaders 0 and 1, but there are visual differences between them because of the way intensity is calculated. not sure if that can ever be rectified...
* glowmaps only load if r_glowmaps is 1
* supported on both models and WALs
* supports glowmaps on alpha & fence textures (re-release lacks this functionality)

things not tested:
* how glowmaps interact if they are not the same size as the input texture
* how glowmaps interact with re-texture projects

![](https://i.imgur.com/OnLNvhM.png)
screenshot of what it looks like currently