### PR TITLE
Make Com_MakePrintable() always enabled (not just when debug is enabled)

### DIFF
--- a/inc/common/utils.h
+++ b/inc/common/utils.h
@@ -68,9 +68,7 @@ color_index_t Com_ParseColor(const char *s);
 unsigned Com_ParseExtensionString(const char *s, const char *const extnames[]);
 #endif
 
-#if USE_DEBUG
 char *Com_MakePrintable(const char *s);
-#endif
 
 // Some mods actually exploit CS_STATUSBAR to take space up to CS_AIRACCEL
 static inline size_t CS_SIZE(const cs_remap_t *csr, int cs)

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -558,8 +558,6 @@ size_t Com_FormatSizeLong(char *dest, size_t destsize, int64_t bytes)
     return Q_scnprintf(dest, destsize, "unknown size");
 }
 
-#if USE_DEBUG
-
 static int get_escape_char(int c)
 {
     switch (c) {
@@ -597,5 +595,3 @@ char *Com_MakePrintable(const char *s)
     *o = 0;
     return buffer;
 }
-
-#endif


### PR DESCRIPTION
Fixes #324.

Alternatively, the problematic warning print could be changed to not use `Com_MakePrintable()`.
