### PR TITLE
Attempt to address legacy 'intensity' behavior

### DIFF
--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -111,6 +111,7 @@ typedef struct {
     byte            latlngtab[NUMVERTEXNORMALS][2];
     byte            lightstylemap[MAX_LIGHTSTYLES];
     hash_map_t      *queries;
+    float           legacy_rgb_scale; // RGB scale (if COMBINE is available) for intensity * modulate application
 } glStatic_t;
 
 typedef struct {

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -139,13 +139,14 @@ typedef struct {
 
 enum {
     QGL_CAP_LEGACY                      = BIT(0),
-    QGL_CAP_SHADER                      = BIT(1),
-    QGL_CAP_TEXTURE_BITS                = BIT(2),
-    QGL_CAP_TEXTURE_CLAMP_TO_EDGE       = BIT(3),
-    QGL_CAP_TEXTURE_MAX_LEVEL           = BIT(4),
-    QGL_CAP_TEXTURE_LOD_BIAS            = BIT(5),
-    QGL_CAP_TEXTURE_NON_POWER_OF_TWO    = BIT(6),
-    QGL_CAP_TEXTURE_ANISOTROPY          = BIT(7),
+    QGL_CAP_LEGACY_TEXCOMBINE           = BIT(1),
+    QGL_CAP_SHADER                      = BIT(2),
+    QGL_CAP_TEXTURE_BITS                = BIT(3),
+    QGL_CAP_TEXTURE_CLAMP_TO_EDGE       = BIT(4),
+    QGL_CAP_TEXTURE_MAX_LEVEL           = BIT(5),
+    QGL_CAP_TEXTURE_LOD_BIAS            = BIT(6),
+    QGL_CAP_TEXTURE_NON_POWER_OF_TWO    = BIT(7),
+    QGL_CAP_TEXTURE_ANISOTROPY          = BIT(8),
 };
 
 #define QGL_VER(major, minor)   ((major) * 100 + (minor))

--- a/src/refresh/main.c
+++ b/src/refresh/main.c
@@ -851,8 +851,7 @@ static void gl_lightmap_changed(cvar_t *self)
     lm.scale = Cvar_ClampValue(gl_coloredlightmaps, 0, 1);
     lm.comp = !(gl_config.caps & QGL_CAP_TEXTURE_BITS) ? GL_RGBA : lm.scale ? GL_RGB : GL_LUMINANCE;
     lm.add = 255 * Cvar_ClampValue(gl_brightness, -1, 1);
-    lm.modulate = Cvar_ClampValue(gl_modulate, 0, 1e6f);
-    lm.modulate *= Cvar_ClampValue(gl_modulate_world, 0, 1e6f);
+    lm.modulate = Cvar_ClampValue(gl_modulate_world, 0, 1e6f);
     if (gl_static.use_shaders && (self == gl_brightness || self == gl_modulate || self == gl_modulate_world) && !gl_vertexlight->integer)
         return;
     lm.dirty = true; // rebuild all lightmaps next frame
@@ -860,8 +859,7 @@ static void gl_lightmap_changed(cvar_t *self)
 
 static void gl_modulate_entities_changed(cvar_t *self)
 {
-    gl_static.entity_modulate = Cvar_ClampValue(gl_modulate, 0, 1e6f);
-    gl_static.entity_modulate *= Cvar_ClampValue(gl_modulate_entities, 0, 1e6f);
+    gl_static.entity_modulate = Cvar_ClampValue(gl_modulate_entities, 0, 1e6f);
 }
 
 static void gl_modulate_changed(cvar_t *self)

--- a/src/refresh/qgl.c
+++ b/src/refresh/qgl.c
@@ -164,6 +164,17 @@ static const glsection_t sections[] = {
         }
     },
 
+    // GL 1.3
+    // GL_ARB_texture_env_combine
+    {
+        .extension = "GL_ARB_texture_env_combine",
+        .ver_gl = QGL_VER(1, 3),
+        .ver_es = QGL_VER(1, 0),
+        .excl_gl = QGL_VER(3, 1),
+        .excl_es = QGL_VER(2, 0),
+        .caps = QGL_CAP_LEGACY_TEXCOMBINE,
+    },
+
     // GL 1.4, compat
     {
         .ver_gl = QGL_VER(1, 4),


### PR DESCRIPTION
This is an attempt to address the current differences in `intensity` vs `gl_modulate` handling, as discussed in eg #322.

This implements two ideas:
* Use COMBINE texture env mode RGB scaling, if available, to avoid having to scale the actual texture data in more cases. (COMBINE mode is GL 1.3).
This isn't perfect, as only the scaling values 1, 2, and 4 are allowed, but at least 2 covers the default case.
* Actually consider `gl_modulate` in `GL_BuildIntensityTable()`. That way it shouldn't matter whether you set `intensity 2; gl_modulate 1` or `intensity 1; gl_modulate 2`, the result is the same.