### PR TITLE
Fix tearing in short-lived dynamic lights at high FPS

### DIFF
--- a/src/client/effects.c
+++ b/src/client/effects.c
@@ -143,7 +143,13 @@ void CL_AddDLights(void)
 
     dl = cl_dlights;
     for (i = 0; i < MAX_DLIGHTS; i++, dl++) {
-        if (dl->die < cl.time)
+        /* Vanilla Quake II had just cl.time. This worked in 1997
+           when computers were slow and the game reached ~30 FPS
+           on beefy hardware. Nowadays with 1000 FPS the dlights
+           are often rendered just a fraction of a frame. Work
+           around that by adding 32 ms, e.g. each dlight is shown
+           for at least 32 ms. */
+        if (dl->die < cl.time - 32)
             continue;
         V_AddLight(dl->origin, dl->radius,
                    dl->color[0], dl->color[1], dl->color[2]);


### PR DESCRIPTION
The tearing occurred because the dynamic light was shown for a single frame, but when running above the monitor refresh rate, less than a single frame was actually visible on screen. Even when V-Sync was used, the dynamic light was visible for a very small portion of time on screen depending on the monitor refresh rate.

The fix works by ensuring each dynamic light is visible for at least 32 milliseconds, which roughly matches the appearance of dynamic lights as they were in vanilla Quake 2 on period-appropriate hardware (running at 30-35 FPS).

Moving dynamic lights (e.g. from rockets) are not impacted by this change - they still move as smoothly as before.

This uses the same fix as Yamagi Quake 2.

- This closes https://github.com/skullernet/q2pro/issues/321.

## Preview

Game is running at 1,000 FPS (60 FPS video):

https://github.com/user-attachments/assets/256517bc-55ed-4191-b008-fdb52d065e58


