### PR TITLE
Fix misrendered window icon

### DIFF
--- a/src/unix/video/sdl.c
+++ b/src/unix/video/sdl.c
@@ -303,8 +303,8 @@ static bool init(void)
 
     SDL_SetWindowMinimumSize(sdl.window, 320, 240);
 
-    SDL_Surface *icon = SDL_CreateRGBSurfaceFrom(q2icon_bits, q2icon_width, q2icon_height,
-                                                 1, q2icon_width / 8, 0, 0, 0, 0);
+    SDL_Surface *icon = SDL_CreateRGBSurfaceWithFormatFrom(q2icon_bits, q2icon_width, q2icon_height,
+                                                           1, q2icon_width / 8, SDL_PIXELFORMAT_INDEX1LSB);
     if (icon) {
         SDL_Color colors[2] = {
             { 255, 255, 255 },


### PR DESCRIPTION
I noticed that the window icon appeared malformed. It seems that the xbm format encodes the image with the first pixels being placed in LSB, while SDL_CreateRGBSurfaceFrom reads it as MSB.

Using `SDL_CreateRGBSurfaceWithFormatFrom(..., SDL_PIXELFORMAT_INDEX1LSB)` fixes this issue.

| before | after |
| ---- | ---- |
| ![Screenshot 2024-11-19 at 00 12 36](https://github.com/user-attachments/assets/f348a52c-fe3b-417d-8591-cbbdea0cd187) | ![Screenshot 2024-11-19 at 00 11 55](https://github.com/user-attachments/assets/6b65c4a0-07e6-419c-8f6b-d008bd12a385) |
