### PR TITLE
Add missing parens for Com_DWPrintf

### DIFF
--- a/inc/common/common.h
+++ b/inc/common/common.h
@@ -144,7 +144,7 @@ void        Sys_Printf(const char *fmt, ...) q_printf(1, 2);
 #define Com_DDPrintf(...) ((void)0)
 #define Com_DDDPrintf(...) ((void)0)
 #define Com_DDDDPrintf(...) ((void)0)
-#define Com_DWPrintf(...) ((void)0
+#define Com_DWPrintf(...) ((void)0)
 #endif
 
 #if USE_TESTS


### PR DESCRIPTION
Ran into this when trying to make a release build from ade82fda