### PR TITLE
Be forgiving with overlong EntString lumps

### DIFF
--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -809,7 +809,7 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
             if (!info->lump) {
                 // EntString workaround for eg ztnmap1
                 Com_WPrintf("%s lump out of bounds, fixing\n", info->name);
-                len = filelen - ofs;
+                len = filelen - min(ofs, filelen);
             } else {
                 Com_SetLastError(va("%s lump out of bounds", info->name));
                 ret = Q_ERR_INVALID_FORMAT;

--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -806,10 +806,10 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
         ofs = LittleLong(header->lumps[info->lump].fileofs);
         len = LittleLong(header->lumps[info->lump].filelen);
         if ((uint64_t)ofs + len > filelen) {
-            if (!info->lump) {
+            if (!info->lump && ofs < filelen) {
                 // EntString workaround for eg ztnmap1
                 Com_WPrintf("%s lump out of bounds, fixing\n", info->name);
-                len = filelen - min(ofs, filelen);
+                len = filelen - ofs;
             } else {
                 Com_SetLastError(va("%s lump out of bounds", info->name));
                 ret = Q_ERR_INVALID_FORMAT;

--- a/src/common/bsp.c
+++ b/src/common/bsp.c
@@ -806,9 +806,15 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
         ofs = LittleLong(header->lumps[info->lump].fileofs);
         len = LittleLong(header->lumps[info->lump].filelen);
         if ((uint64_t)ofs + len > filelen) {
-            Com_SetLastError(va("%s lump out of bounds", info->name));
-            ret = Q_ERR_INVALID_FORMAT;
-            goto fail2;
+            if (!info->lump) {
+                // EntString workaround for eg ztnmap1
+                Com_WPrintf("%s lump out of bounds, fixing\n", info->name);
+                len = filelen - ofs;
+            } else {
+                Com_SetLastError(va("%s lump out of bounds", info->name));
+                ret = Q_ERR_INVALID_FORMAT;
+                goto fail2;
+            }
         }
         if (len % info->disksize[extended]) {
             Com_SetLastError(va("%s lump has odd size", info->name));


### PR DESCRIPTION
Some(*) maps have incorrect sizes recorded for their EntString lumps - the lump size in the header goes beyong the end of the file. (Probably some botched edit of a compiled map.)
The contained entity string is otherwise fine & correct, so try to be tolerant here and fix the lump to go to the end of the file.

(*) Motivated by ztnmap1 which is shipped in "Quake 2: Quad Damage", available on GoG. So there's a decent chance to run into this issue without even downloading some maps off the net.