### PR TITLE
SDL2 echo in console fix

### DIFF
--- a/src/unix/video/sdl.c
+++ b/src/unix/video/sdl.c
@@ -492,7 +492,9 @@ static void pump_events(void)
             break;
         case SDL_KEYDOWN:
         case SDL_KEYUP:
-            key_event(&event.key);
+            if (!event.key.repeat) {
+                key_event(&event.key);
+            }
             break;
         case SDL_MOUSEMOTION:
             if (sdl.win_width && sdl.win_height)


### PR DESCRIPTION
In the Q2Pro client, when I set vid_driver to sdl and use SDL2, every key press in the console is echoed twice — for example, pressing a key like a results in aa being printed.

After investigating the issue, I discovered that it was caused by SDL2 generating repeated key events, or possibly a combination of SDL_KEYDOWN and SDL_TEXTINPUT events being processed.

To fix the problem, I had to modify the input handling code and add the following condition to filter out repeated key events.

This change ensures that only the initial key press is processed, and it successfully prevents the duplicated character input (the "echo").

https://github.com/user-attachments/assets/aed16ac3-978f-471d-b3c7-8220f4df961e

